### PR TITLE
Added comparisons of EigenGame with sklearn.decomposition.PCA

### DIFF
--- a/NeuralABC_tools/__init__.py
+++ b/NeuralABC_tools/__init__.py
@@ -1,4 +1,4 @@
 from .arrays import  *
 from .conv_functions import *
-from .eigengame import *
+from .eigengame import eigengame
 from .Parallelize import *

--- a/NeuralABC_tools/__init__.py
+++ b/NeuralABC_tools/__init__.py
@@ -1,4 +1,4 @@
 from .arrays import  *
 from .conv_functions import *
 from .eigengame import eigengame
-from .Parallelize import *
+from .Parallelize import Parallelize

--- a/NeuralABC_tools/eigengame.py
+++ b/NeuralABC_tools/eigengame.py
@@ -1,7 +1,5 @@
 import numpy as np
 
-
-
 def calc_penalties(data, vectors, index):
     """
     calc_penalties is a helper function used by eigengame() and should never be called outside
@@ -95,6 +93,7 @@ class EigenGame():
                 vectors[:, t] = vectors[:, t] / np.linalg.norm(vectors[:, t])
 
         self.eigenvectors = vectors.T
+        self.components = data @ self.eigenvectors.T
         return vectors
     
     def get_explained_variance_ratio(self):
@@ -113,7 +112,6 @@ class EigenGame():
             covariance_matrix_trace += np.dot(row, row)
         
         return explained_variance_ratios / covariance_matrix_trace
-
 
      
 def eigengame(data, n_components, epochs=100, learning_rate=0.1):

--- a/NeuralABC_tools/eigengame.py
+++ b/NeuralABC_tools/eigengame.py
@@ -2,6 +2,35 @@ import numpy as np
 
 
 
+def calc_penalties(data, vectors, index):
+    """
+    calc_penalties is a helper function used by eigengame() and should never be called outside
+    of it. 
+    
+    Parameters:
+    ----------------
+    :param data: (2D array), required: the data array for which we want to run PCA on.
+    :param vectors: (2D array), required: the collection of eigenvectors that are being calculated by eigengame()
+    :param index: (int), required: the index of the vector within vectors that we want to calculate the penalty for
+    
+    Returns:
+    ----------------
+    :returns penalties: The penalties array, which will be used by eigengame() to calculate the vector update
+    References:
+    ----------------
+    "EigenGame: PCA as a Nash Equilibrium"; Gemp et al., 2020 
+    """
+    vec = vectors[:, index]
+    penalties = np.zeros_like(np.dot(data, vectors[:, 0]))
+    
+    for i in range(index):
+        result = np.dot(data, vectors[:, i])
+        penalties += (np.dot(np.dot(data, vec), result) /
+         np.dot(result, result)
+        ) * result
+
+    return penalties 
+
 class EigenGame():
     def __init__(self, n_components, epochs=100, learning_rate=0.1):
         
@@ -47,6 +76,7 @@ class EigenGame():
         ----------------
         "EigenGame: PCA as a Nash Equilibrium"; Gemp et al., 2020 
         """
+        data = data.T
         self.data = data
 
         n_components = self.n_components
@@ -65,7 +95,7 @@ class EigenGame():
                 vectors[:, t] = vectors[:, t] / np.linalg.norm(vectors[:, t])
 
         self.eigenvectors = vectors.T
-        return vectors.T
+        return vectors
     
     def get_explained_variance_ratio(self):
         explained_variance_ratios = []
@@ -85,34 +115,6 @@ class EigenGame():
         return explained_variance_ratios / covariance_matrix_trace
 
 
-def calc_penalties(data, vectors, index):
-    """
-    calc_penalties is a helper function used by eigengame() and should never be called outside
-    of it. 
-    
-    Parameters:
-    ----------------
-    :param data: (2D array), required: the data array for which we want to run PCA on.
-    :param vectors: (2D array), required: the collection of eigenvectors that are being calculated by eigengame()
-    :param index: (int), required: the index of the vector within vectors that we want to calculate the penalty for
-    
-    Returns:
-    ----------------
-    :returns penalties: The penalties array, which will be used by eigengame() to calculate the vector update
-    References:
-    ----------------
-    "EigenGame: PCA as a Nash Equilibrium"; Gemp et al., 2020 
-    """
-    vec = vectors[:, index]
-    penalties = np.zeros_like(np.dot(data, vectors[:, 0]))
-    
-    for i in range(index):
-        result = np.dot(data, vectors[:, i])
-        penalties += (np.dot(np.dot(data, vec), result) /
-         np.dot(result, result)
-        ) * result
-
-    return penalties 
      
 def eigengame(data, n_components, epochs=100, learning_rate=0.1):
     """

--- a/NeuralABC_tools/eigengame.py
+++ b/NeuralABC_tools/eigengame.py
@@ -1,5 +1,90 @@
 import numpy as np
 
+
+
+class EigenGame():
+    def __init__(self, n_components, epochs=100, learning_rate=0.1):
+        
+        """
+        EigenGame implements the "EigenGame" algorithm, developed by
+        Gemp et al. in 2020
+        
+        Constructor parameters:
+        ----------------
+        :param data: (2D array), required: a Numpy array containing the data to run PCA on, in the form (features, samples) 
+        :param n_components: (int), required: the number of principal components to extract
+        :param epochs: (int), optional: the number of iterations to calculate each eigenvector. Default = 100
+        :param learning_rate: (float), optional: Learning rate of the algorithm. Default = 0.1
+
+        Returns:
+        ----------------
+        None
+
+        References:
+        ----------------
+        "EigenGame: PCA as a Nash Equilibrium"; Gemp et al., 2020 
+        """
+        
+        self.n_components = n_components
+        self.epochs = epochs
+        self.learning_rate = learning_rate
+    
+    def fit_transform(self, data):
+        """
+        fit_transform() performs PCA on input data using the "EigenGame" algorithm, developed by
+        Gemp et al. in 2020
+
+        Parameters:
+        ----------------
+        None
+        
+        Returns:
+        ----------------
+        vectors
+        :returns vectors: the principal components, stacked horizontally
+
+        References:
+        ----------------
+        "EigenGame: PCA as a Nash Equilibrium"; Gemp et al., 2020 
+        """
+        self.data = data
+
+        n_components = self.n_components
+        learning_rate = self.learning_rate
+        epochs = self.epochs
+        
+        dim = data.shape[1]
+        vectors = np.ones((dim, n_components))
+        for t in range(n_components):
+            for epoch in range(epochs):
+                rewards = np.dot(data, vectors[:, t])
+                penalties = calc_penalties(data, vectors, t)
+
+                delta_v = 2*np.dot(data.T, rewards - penalties)
+                vectors[:, t] = vectors[:, t] + learning_rate * delta_v
+                vectors[:, t] = vectors[:, t] / np.linalg.norm(vectors[:, t])
+
+        self.eigenvectors = vectors.T
+        return vectors.T
+    
+    def get_explained_variance_ratio(self):
+        explained_variance_ratios = []
+        
+        cov_matrix_firstrow = np.zeros((self.data.shape[1]))
+        for i in range(self.data.shape[1]):
+            cov_matrix_firstrow[i] = np.dot(self.data[:,0], self.data[:,i])
+        
+        
+        for v in self.eigenvectors:
+            explained_variance_ratios.append(np.dot(v, cov_matrix_firstrow) / v[0])
+        
+        covariance_matrix_trace = 0
+        for row in self.data:
+            covariance_matrix_trace += np.dot(row, row)
+        
+        return explained_variance_ratios / covariance_matrix_trace
+
+
 def calc_penalties(data, vectors, index):
     """
     calc_penalties is a helper function used by eigengame() and should never be called outside
@@ -14,7 +99,6 @@ def calc_penalties(data, vectors, index):
     Returns:
     ----------------
     :returns penalties: The penalties array, which will be used by eigengame() to calculate the vector update
-
     References:
     ----------------
     "EigenGame: PCA as a Nash Equilibrium"; Gemp et al., 2020 

--- a/NeuralABC_tools/tests/EigenGame usage.ipynb
+++ b/NeuralABC_tools/tests/EigenGame usage.ipynb
@@ -285,6 +285,32 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " Explained variance ratio determined by EigenGame:  [0.10558267] \n",
+      " Explained variance ratio determined by SKlearn's PCA:  [0.07373841]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\" Explained variance ratio determined by EigenGame: \", eg.get_explained_variance_ratio(), \"\\n\", \n",
+    "     \"Explained variance ratio determined by SKlearn's PCA: \", pca.explained_variance_ratio_)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],

--- a/NeuralABC_tools/tests/EigenGame usage.ipynb
+++ b/NeuralABC_tools/tests/EigenGame usage.ipynb
@@ -1,0 +1,315 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/remoteuser/neuralabc_volunteer/.local/lib/python3.8/site-packages/nilearn/input_data/__init__.py:27: FutureWarning: The import path 'nilearn.input_data' is deprecated in version 0.9. Importing from 'nilearn.input_data' will be possible at least until release 0.13.0. Please import from 'nilearn.maskers' instead.\n",
+      "  warnings.warn(message, FutureWarning)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from sklearn.decomposition import PCA\n",
+    "from nilearn import datasets, plotting, masking, image, input_data\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import StandardScaler\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Implement the EigenGame class\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "def calc_penalties(data, vectors, index):\n",
+    "    \"\"\"\n",
+    "    calc_penalties is a helper function used by eigengame() and should never be called outside\n",
+    "    of it. \n",
+    "    \n",
+    "    Parameters:\n",
+    "    ----------------\n",
+    "    :param data: (2D array), required: the data array for which we want to run PCA on.\n",
+    "    :param vectors: (2D array), required: the collection of eigenvectors that are being calculated by eigengame()\n",
+    "    :param index: (int), required: the index of the vector within vectors that we want to calculate the penalty for\n",
+    "    \n",
+    "    Returns:\n",
+    "    ----------------\n",
+    "    :returns penalties: The penalties array, which will be used by eigengame() to calculate the vector update\n",
+    "    References:\n",
+    "    ----------------\n",
+    "    \"EigenGame: PCA as a Nash Equilibrium\"; Gemp et al., 2020 \n",
+    "    \"\"\"\n",
+    "    vec = vectors[:, index]\n",
+    "    penalties = np.zeros_like(np.dot(data, vectors[:, 0]))\n",
+    "    \n",
+    "    for i in range(index):\n",
+    "        result = np.dot(data, vectors[:, i])\n",
+    "        penalties += (np.dot(np.dot(data, vec), result) /\n",
+    "         np.dot(result, result)\n",
+    "        ) * result\n",
+    "\n",
+    "    return penalties \n",
+    "\n",
+    "class EigenGame():\n",
+    "    def __init__(self, n_components, epochs=100, learning_rate=0.1):\n",
+    "        \n",
+    "        \"\"\"\n",
+    "        EigenGame implements the \"EigenGame\" algorithm, developed by\n",
+    "        Gemp et al. in 2020\n",
+    "        \n",
+    "        Constructor parameters:\n",
+    "        ----------------\n",
+    "        :param data: (2D array), required: a Numpy array containing the data to run PCA on, in the form (features, samples) \n",
+    "        :param n_components: (int), required: the number of principal components to extract\n",
+    "        :param epochs: (int), optional: the number of iterations to calculate each eigenvector. Default = 100\n",
+    "        :param learning_rate: (float), optional: Learning rate of the algorithm. Default = 0.1\n",
+    "\n",
+    "        Returns:\n",
+    "        ----------------\n",
+    "        None\n",
+    "\n",
+    "        References:\n",
+    "        ----------------\n",
+    "        \"EigenGame: PCA as a Nash Equilibrium\"; Gemp et al., 2020 \n",
+    "        \"\"\"\n",
+    "        \n",
+    "        self.n_components = n_components\n",
+    "        self.epochs = epochs\n",
+    "        self.learning_rate = learning_rate\n",
+    "    \n",
+    "    def fit_transform(self, data):\n",
+    "        \"\"\"\n",
+    "        fit_transform() performs PCA on input data using the \"EigenGame\" algorithm, developed by\n",
+    "        Gemp et al. in 2020\n",
+    "\n",
+    "        Parameters:\n",
+    "        ----------------\n",
+    "        None\n",
+    "        \n",
+    "        Returns:\n",
+    "        ----------------\n",
+    "        vectors\n",
+    "        :returns vectors: the principal components, stacked horizontally\n",
+    "\n",
+    "        References:\n",
+    "        ----------------\n",
+    "        \"EigenGame: PCA as a Nash Equilibrium\"; Gemp et al., 2020 \n",
+    "        \"\"\"\n",
+    "        data = data.T\n",
+    "        self.data = data\n",
+    "\n",
+    "        n_components = self.n_components\n",
+    "        learning_rate = self.learning_rate\n",
+    "        epochs = self.epochs\n",
+    "        \n",
+    "        dim = data.shape[1]\n",
+    "        vectors = np.ones((dim, n_components))\n",
+    "        for t in range(n_components):\n",
+    "            for epoch in range(epochs):\n",
+    "                rewards = np.dot(data, vectors[:, t])\n",
+    "                penalties = calc_penalties(data, vectors, t)\n",
+    "\n",
+    "                delta_v = 2*np.dot(data.T, rewards - penalties)\n",
+    "                vectors[:, t] = vectors[:, t] + learning_rate * delta_v\n",
+    "                vectors[:, t] = vectors[:, t] / np.linalg.norm(vectors[:, t])\n",
+    "\n",
+    "        self.eigenvectors = vectors.T\n",
+    "        self.components = data @ self.eigenvectors.T\n",
+    "        return vectors\n",
+    "    \n",
+    "    def get_explained_variance_ratio(self):\n",
+    "        explained_variance_ratios = []\n",
+    "        \n",
+    "        cov_matrix_firstrow = np.zeros((self.data.shape[1]))\n",
+    "        for i in range(self.data.shape[1]):\n",
+    "            cov_matrix_firstrow[i] = np.dot(self.data[:,0], self.data[:,i])\n",
+    "        \n",
+    "        \n",
+    "        for v in self.eigenvectors:\n",
+    "            explained_variance_ratios.append(np.dot(v, cov_matrix_firstrow) / v[0])\n",
+    "        \n",
+    "        covariance_matrix_trace = 0\n",
+    "        for row in self.data:\n",
+    "            covariance_matrix_trace += np.dot(row, row)\n",
+    "        \n",
+    "        return explained_variance_ratios / covariance_matrix_trace"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(168, 24256)\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Grab one subject from the dataset\n",
+    "data = datasets.fetch_development_fmri(n_subjects=1)\n",
+    "\n",
+    "#Calculate the mask\n",
+    "avg_img = image.mean_img(data.func[0])\n",
+    "mask = masking.compute_epi_mask(avg_img)\n",
+    "our_masker = input_data.NiftiMasker(mask_img=mask)\n",
+    "\n",
+    "#Convert data to an array\n",
+    "X = our_masker.fit_transform(data['func'][0])\n",
+    "print(X.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Instantiate a PCA object from SKLearn\n",
+    "pca = PCA(n_components=1)\n",
+    "\n",
+    "#We shall scale the data before passing it to SKLearn's PCA\n",
+    "scaler = StandardScaler()\n",
+    "X_normed = scaler.fit_transform(X)\n",
+    "\n",
+    "sklearn_pca_results = pca.fit_transform(X_normed.T)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 16.5 s, sys: 707 ms, total: 17.2 s\n",
+      "Wall time: 411 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "#Create an EigenGame object and pass our data to it\n",
+    "\n",
+    "eg = EigenGame(n_components=1)\n",
+    "eigengame_pca_results = eg.fit_transform(X_normed.T.astype(np.float64))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 1.        , -0.97887198],\n",
+       "       [-0.97887198,  1.        ]])"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAdUAAAEICAYAAAAJGW4GAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/NK7nSAAAACXBIWXMAAAsTAAALEwEAmpwYAAA/BElEQVR4nO3de3xU9Z34/9d7JglKRYiAgIQEKUgF/NYlEeJ3vbbet10Qb4jf1e5Wsbv6dbttd3Vry/pDtw/b/fbby7dsFa3bywpaxQt16yooSq0GSFItF4vESMIg1xCQezKZ9++PzznhZDIzSWCSueT9fDwCM+ecOfM5M+fM+3zuoqoYY4wx5sSFMp0AY4wxJl9YUDXGGGPSxIKqMcYYkyYWVI0xxpg0saBqjDHGpIkFVWOMMSZNsj6oisiXROStE3j9yyJyWzrT5O335yLyULr3azJDRMaKiIpIwQnup8/OixO9NrKViLwhIrcf52sPiMi4dKepvziRzz6wj0tEJJKuNHXj/VRExvfV+3WlW0FVROaISLV3wm7zAtUFvZ24nhKRB0TkP4PLVPVqVf1FptKUSC4EZO/iOiIiYwLLLhORzb30fg+ISKt3ju0VkbdF5PzeeK9skY4fsBT79m8SDnh/m0XkvsB6EZF7RGSdiBwUkYiIPCMi53jrLxWRFSKyr7e+8+MRd574f3v99ap6iqrW90E6RETuFpE/isghEdnufZ+ze/u980lv3xgGfscOiMhuEXlOREYF1k8Tkd96vzl7RGS1iPy1t65IRJ71rh0VkUu6855dBlUR+RrwQ+A7wAigFPh3YMZxHGCnXMCJ5gxMrzoIfLsP3+9pVT0FGA68BTwnItKH75+Phnif6c3APBG5ylv+I+DvgXuA04CzgBeAv/DWHwSeAP6xT1PbPU97wdP/G5KBNPwY+CrwdWAoMBr4FnBViteYzLjbuwbOAoYAPwDwbtpfB94ExuO+x78Frg689i3gfwHbu/1uqpr0DxgMHABuSLHNAFzQ/dj7+yEwwFt3CRAB7vUS9SvgAeBZ4D+BT4Dbvff5GbAN2Ao8BIS9fXwJeCvwfj8CtnivrQEu9JZfBbQArV6a3/OWvwHc7j0O4U78BmAn8EtgsLduLKDAbUAjsBu4P8Vx/xx4BFgG7Pe+mLLA+s946/YAG4EbveVzvTS2eOn8DfDXwG8Cr90EPBN4vgU4N9V+A9/F//HSv8NL38lx38XXvWPfBvx1iuN7A/gX79g+7S27DNgc2EaB8XGfyUNx7/dPgfebCVwDfOCl/5uB1z4A/Gfg+WRv/6d7254TWHc6cAgYniTtFwBvA3u9z+5L3vK/AP6AO3e2AA8EXuN//wXe89OA/8Cd083AC4nOx/jPIe4zKAZeAnZ5+3gJKPHW/SvQBhzxzoOfdOP7HQos9dK/GngwPi3Jjsdbtgb4BjDBe+9pqa7/RN95iu2ewV3j+4CVwOS482IB8F/e+bTKP6e89ZcDf/Je+xPctXR7kvfpcJ4kWB/8Lobirq9PvGN/iI6/Jak+66Rpxv04twEVXXwmfw28772+HrgzsO4SenZ9hID7gA+BJuDXwGkp3jvZ+Zv0nIz/vfSe3xE4hg3A1O5e+4F1frr9fVzrLT8bd/634a6BvV39jnnr/9H7vD4G/iY+LQl+x4LHcxewznv8FrCgq3Pb2zYCXNKdbbvKqZ4PnAQ8n2Kb+4FK4Fzgs8A0XODyjcR9wWW4gAIul/ss7q7hSdwXEsXdLfwZcAUu2Cayxnuv04BFwDMicpKq/jcuN+3fxX42wWu/5P1dCowDTsFdxEEXABOBz+Pu7M9Ocey34H7YhgHveseCiHwKd7EuwgWA2cC/i8gkVV3obfc9L51fxP2IXCgiIRE5AyjCffZ49UOnAH9MtV8vPQ/jLvhzcZ/laGBeIL0jcTcwo4EvAwtEpDjF8W0FHgP+vxTbpDISd/746XgMd9dXDlwIfFtEzox/kYgMwH1PW1R1J/CU9zrfzcBrqrorwWvLgJeB/4fL8Z6L+27A5b5uxZ13fwH8rYjMTJL2XwEDccH9dLy72x4K4X7YynAlPIfxzjdVvR/4Hd5dtKre3Y3vdwHuR2gU7sfkb7qTCK+o8s+9Y/kD7tyOqOrq4zimZF7GBevTgVq8ayFgNu48KgbqcDcViMgw4Dncb8Yw3I/vn6cpTQtw3/lI3M1ye9uKbnzWSdMMfA53blZ38f47gS8Ap+IC7A9EZGpgfU+uj/+NC7oXA2fgAuKCFO+d7PxNek7GE5EbcDcxt3rH8Je4gN5TH3rHMxj3ef6niIxS1feBrwDvaMcSh6S/Y15JyzdwN2ITcDd93eKda9cBfxCRgbjf2GeP43hS6yI63wJs72KbD4FrAs+vxLuzxd2xtAAnxd1prgw8HwEcpeOdyM3ACu/xl0hyN+6tbwY+m+wulo451deAvwusm4jLNRZw7M4+eNe2Gpid5H1/DjwVeH4K7o5rDHAT8Lu47R8F/iX+ri6wfgswFXchL/Te+zO4i3Gpt03S/QKC+wEJ5gDOBz4KfBeH6Zhz2QlUprrDwwWmfbiLs6c51cMcK3EY5G0/PbB9DTAz8N214HKXO3HFMuXeuum4u1bxnlcTyFXEpfufgee7eff5Q+AH3mP/+y/ABa0YUJzgNV+imznVBK89F2hOdG524/sN487VzwTWfSc+LYF1/vHsxV0j7wP3eOvuB6q6+Rl1K6ca95oh3nsPDnwmjwfWXwP8yXt8azAtuPM4Quqcqn+e+H8r4r+LwOc1MbCuPaea6rPuRpq/Ff/5eWnei7vpKUuS9heAvz/O6+N94POBdaO84ytI8D5Jz9+enJPAK356E7yu2znVBK99F5iR6Hqi69+xJ4CHA+vOik9L3Hu9gSvV2ovLJDyJ+00b7b3uM8nSmeD7vaQ723ZVn9kEDBORAlWNJtnmDFxxqq/BW+bbpapH4l6zJfC4DCgEtgWqz0Jx27QTkW/gcllneB/Kqbg73O5IlNYCXGD3BcvOD+GCZTLtaVTVAyKyx3uPMmB6sAGF9z6/SrGvN3En43jv8V7cXen53nO62O9w3J1pTeBzFNyPi68p7nvs6vhQ1V0i8hNgPvDTVNsm0KSqbd7jw97/OwLrD8e9/69VNZgj9dOwSkQOAZeIyDbcZ7QUXGvPwKaTcDc1HyZKjIhMx90FT8GVBgzAFVvGGwPsUdXm1IeXmnc3/ANc1YRfIjBIRMKBzyWoq++3gI7XRfBcTmZYgmu3CffDmxYiEsbl4m7ApTPmvzfuhgySX1dn0PE6UhFJeO0HJDxP4iT6vOJ/d7q6RpOludPnp6olXvuQVtx1h4hcjbshOgv3mzYQWBt4WU+ujzLgeRGJBda3ASNE5NscK8n5DrCcJOdvD8/JpNdST4jIrcDXcDd64I4p2W92V79jZ+BuNnzduQbuUdXH49I0EHeejsJVPaRNV8W/7+BykTNTbPMx7gv3lXrLfJrgNcFlW7z3GKaqQ7y/U1V1cvyLRORCXB3Ejbi7sCG4i9b/9BO9V1dpjdLxRO6JYMvYU3BF0h/jjunNwPEMUVe88bcp0ukH1Qu9x2/igurFHAuqqfa7G3cRTg6sG6yugv5E/RuuyLw8bvkh3AXgG5mG90rmF7gfjr8CnvVv1LRjg5VG3Gf06ST7WIQLxmNUdTCuriZRQ6gtwGkiMiTBuoMEjllEUh3z13GlIdNV9VTgIv9l3v/x50Gq73cX7lwdE9i+NMV7p/IaUCIiFcf5+nhzcFU6l+GK+MZ6y7vTyGwbHa8joeMxHi//8yoJLAvut6trNJXX6eLz86owluDqBkd4v1W/pXufSSJbgKvj0nuSqm5V1a8EroHvkPr87eqcjH/PZNdSt659rzrmMeBuYKj3Oawj+TXQ1e9Yh/OF47wGVPUQLr5ddzyvTyVlUFXVfbiy7AUiMlNEBopIoYhcLSLf8zZbDHxLRIZ7ZdbzcI2QukVVtwGvAt8XkVO9esVPi8jFCTYfhLtQdgEFIjIPl1P17QDGikiy41oM/IOInOkFQb8ONlkuvCvXiMgFIlKEq1utUtUtuMr/s0Tkr7zPq1BEzgvUz+7A1ekGvYkLXCeragRX33YVrrHFH7xtku5XVWO4k/cHInI6gIiMFpErj/PY2qnqXuD7uBuaoHeBOSIS9uo6En1n6fKfwLW4wPrLFNs9CVwmIjeKSIGIDBWRc711g3B38EdEZBouGHTinZMv4+rYir3P2f/xeQ+YLCLnishJuOLIZAbhfiD2ishpuFxLUPx5kOr7bcPVPT7gXYeTCNQR9oSqbsK14F8srk9hkYicJCKzxet2412HJ+FKkcRbX5TiOI/icnADcddVd/0X7vOc5eX07iENN2cJPq/P4IqafV1do6n2vRFXVPyUiFwuIid7ufX/GdjMLwnZBUS9XOsVJ3BIjwD/6gUpvN/bGUnSl+r87eqcDHoc+IaIlIsz3n9/un/tfwoXOHd56f5rXEmRbwfuBqXIS3tXv2O/Br4kIpO83Gaq9Hfln7x9/aOIDPXe67Mi8pS/gYgM8K4DAP86SXlj1GWXGlX9Pi7r/i3cB7MFd9fxgrfJQ7g6rj/iijZqvWU9cSvuJNyAq/95lsTFU68A/41rHdeAq78IFun4RXlNIlKb4PVP4Ip3VgIfea//3z1Ma9Ai3Je6B5eL+18AqrofdwHNxuVctwPfxV1k4Fo6TxLXN+oF7zUf4FrA/c57/gmuxeDv/WKZbuz3XlyDiioR+QRXDDTxBI4v6Ee44qagvwe+iCuqvoVj50TaeTcrtbgL9HcptmvE1X99Hfe9vItrQAfwd8B8EdmPu/n7dYq3/CtcUd6fcHW8X/X2/wGuKHw5rpV2qj52PwROxt19V+HO3aAfAdeLSLOI/Lgb3+/duKKz7bg6rP9I8d5duQfXQGUB7vv7EHfT8htv/UW4H9/fcqxBy6tJ9vVL3PW4FXcNV3U3Eaq6G1ds/DAuKE8Aft/Fy26Sjv1UD/g/wHHuxuWc/Z4Hi3HBvzvXUlfuwnWr+b+48yyCu7G+CWj09n8P7hxrxt3ALe3mvhP5kff6V73ztwrX1iCZhOcvXZ+T7VT1GVyx/iJcy90XcKVx0M1rX1U34G7I38EF0HPo+P2+DqwHtovIbm9Z0t8xVX3ZO4bXvW1eT/4RpKaqb+ManX0OqBdXfbcQd877NuLO/dG4+HOYjqWdnfgNP4zJeiLyBPCxqn6ry42NiSMi3wVGqupx5fCN6Q4beMHkBBEZC8zCdbkypktekW8RrgTtPFwDx14ZwcoYX9aP/WuMiDyIa9zwb6r6UabTY3LGIFy96kHgaVwx5IsZTZHJe1b8a4wxxqSJ5VSNMcaYNLE61YBhw4bp2LFjM50MY4zJKTU1NbtVdXim05ENLKgGjB07lurqrobzNMYYEyQi3RnZqF+w4l9jjDEmTSyoGmOMMWliQdUYY4xJEwuqxhhjTJpYUDXGGGPSxIKqMcYYkyYWVNOkpqGZBSvqqGk4oXmtjTHG5DDrp5oGNQ3N3PJ4FS3RGEUFIZ68vZLysuJMJ8sYY0wfs5xqGlTVN9ESjRFTaI3GqKpvynSSjDHGZIAF1TSoHDeUooIQYYHCghCV44ZmOknGGGMywIp/06C8rJgnb6+kqr6JynFDOxX91jQ0J12Xarvuvs4YY0x2sKCaJuVlxQmD6XO1EZ6p3kI0pknrW2samllSG+HZmgjRthgF4RAXnzWcNz/YRbTN6mmNMSZXWFDtJX7jpaOtMfwZa1taYzxXG+mUG+20XTTGsg072vfV0hrjh8s/4KuXnWWB1RhjspgF1V7iN14KTgEfAxatakRxldnjTj+FccM+1Wm7eDHgrU27eefDJm6/4EwGnVxoRcLGGJOFLKj2Er/xUjAHCrQ/jgF1Ow9Qt/MAgguyItCWJLoqEI0pj6ysR4ABhZ2LhK0O1hhjMsuCai+6bmoJO/cf5bX3dxBLkRVVXEC948JxPPa7+k6BVaBTYG7xuu74Rcjdqbs1xhjTuyyo9oL4wSAqyopZvTn1SEsxhf1HowweWMieg60d1iWLx1v3HmbRqkbmv7S+Q464NRBwjTHG9B0Lqr0gfjCICSMG8W5kH63RGJA8SC5a1chJhd3rOhxTWLyqERE65IIF6ytrjDGZYkG1F/j1qa3RGIUFIWZNLWHW1BKq6pt4d8veDi17gxQ43Brr9vsooHER+vJJI7jz4k9bLtUYYzJANP5XuR+rqKjQ6urqtOwrWaOhmoZmbnzk7aQNkk7UyFMHUDluKE0HW7h6yigmjhxEVX0TxQOLWPfxPgSYNbXEgq4xJm1EpEZVKzKdjmxgQTUgnUE1lUWrGpn34jpiMU3Z4jcdCkKueDhYRFwQFp6eez6AtRY2xpwwC6rHZE3xr4hcBfwICAOPq+rDcesHAL8EyoEm4CZV3SwiQ4FngfOAn6vq3YHXvAGMAg57i65Q1Z29fSxdmTO9lIkjB7GkNsLTa7Z0LsNNo2iC0uRom3LP4lp2HWixEZuMMSaNsmJAfREJAwuAq4FJwM0iMilusy8Dzao6HvgB8F1v+RHg28A3kuz+FlU91/vLeED1lZcVM3rIybSl6mvTi7buPdKhMdVztRGbD9YYY05QtuRUpwF1qloPICJPATOADYFtZgAPeI+fBX4iIqKqB4G3RGR8H6Y3LSrHDe3UB3X4KUXsOtDSZ2kQIBwOWR9XY4xJg6zIqQKjgS2B5xFvWcJtVDUK7AO602/kP0TkXRH5tohI/EoRmSsi1SJSvWvXruNLfRqNHfYpwn35rQh8tmQwrW1KTOGoN86w5ViNMabnsiWo9pZbVPUc4ELv76/iN1DVhapaoaoVw4cP79PEVdU3EQzzIeCsEYOIdb9XzQlTherNze25ZcWNM3zL41UWWI0xpoeyJahuBcYEnpd4yxJuIyIFwGBcg6WkVHWr9/9+YBGumDlr+P1ZQwIFIeGha89h1tQSQp3y070nvvgZ77k/KpMxxpjuy5Y61TXABBE5Exc8ZwNz4rZZCtwGvANcD7yuKfoDeYF3iKruFpFC4AvA8t5I/PFKNrn5HReO45GV9X2ShmQfoCq8t2Vve27Vut4YY0zXsiKoqmpURO4GXsF1qXlCVdeLyHygWlWXAj8DfiUidcAeXOAFQEQ2A6cCRSIyE7gCaABe8QJqGBdQH+u7o+qeRJObDzq5MGEOsi/FgFc37GDFxp0IdGrEZDPiGGNMZ1kRVAFU9bfAb+OWzQs8PgLckOS1Y5Pstjxd6etLleOGUhgWWnpzVIhuag2kwZ8sffKoU3n8rY9oi2nCKeiMMaa/ypY6VRNQXlbM4rnnc/mkEe31qyJwbsngjKYrBvxu024eWVlPNKYorrWw1b0aY4xjQTVLlZcV89itFTw08xwKQgIK70b2ZTpZnSjw5sad1lLYGGOwoJr1mg+1EFPNaP1qV1Zvbuamhe+waFWjjcpkjOnXsqZO1STmd7vxhxTMdAOmZKJtyv3Pr0WBsMCDM89hzvTSTCfLGGP6lAXVLBfsdlM8sIjmQy0UDyziibfqqdt1MNPJ68AP9m0K9z+/lvUf77Np5owx/YoF1RyQqNvN02saM5Sa7lHgyVWNLKmNMO8Lk2k+1ELlODeqZLKuONZNxxiT6yyo5qibzivlvcjaTCejS0daY27uWFVEBBGIJRi4v6ahmVser6IlalPRGWNylwXVHOXXV/74tQ/Y/snRDKcmtag/vV1gAKyWaIwltRGeq42wa/9RdnzScSq6qvomC6rGmJxjQTWHzZleyrqP97FoVXYXBScSU1i8qrFToysBRITigUWZSJYxxpwQ61KT466bWkJRuA9H4E+jZK2Y22LK/JfWW9ccY0zOsaCa4/zRl26ZXkpRWAh7M97kKvX+WmyWHGNMDrLi3zzgtw6eNbWEJbURdu8/yoqNOzuM25trRKS9tbAxxuQKC6p55rnaCC3RGAUhYdrYYlZvzs0i1KmlQ1hSG+HRNz8EYNigAVxnfV6NMVnOgmoeqapvam9B62aQCWftCExdWbO5mTVxNwTPVm9h8dzzLbAaY7KW1anmEX9Iw7BAYUGIq6eMojDQiKmoIMRXLhpHjrZroqVNWVIbyXQyjDEmKcup5pHgkIb+qEQTRw5iSW0EAWZNLQGgfvdBlm/YQSyzyT0uz1RvYcoZg9tHaLJcqzEmm4hqLhYO9o6Kigqtrq7OdDJ6jT9q0dHWWE4WCfsKQkJMO47KZEMcGpM5IlKjqhWZTkc2sJxqP+LXufoBNVfrW/0Rmo62xvjh8g+4esoo5r+03oY4NMZknAXVfsSvc22NxgiHQ1xfXsLu/Ud5dcOOTCftuCjw1qbdvPNhE20xN+esDXFojMkkC6r9SKI615qGZt74YBct0VysYXWBtS2miICoa6Bl/VuNMZmSNa1/ReQqEdkoInUicl+C9QNE5Glv/SoRGestHyoiK0TkgIj8JO415SKy1nvNj0UkR9u9pk95WTF3XTq+PSdXXlbM4jsq+ccrJ3Le2NzM3SluLOFQSJj3hcmWSzXGZExWBFURCQMLgKuBScDNIjIpbrMvA82qOh74AfBdb/kR4NvANxLs+qfAHcAE7++q9Kc+95WXFVM5bijvRfa1L8vFu49oTPnBso3UNDRT09DMghV1CccPTrXOGGNORLYU/04D6lS1HkBEngJmABsC28wAHvAePwv8REREVQ8Cb4nI+OAORWQUcKqqVnnPfwnMBF7uxePIWVX1TUTbXBGwAGePGsSGbfszm6jjsOtAC9f99O32RlgicOeF47jvmrMBm7fVGNO7siKnCowGtgSeR7xlCbdR1SiwD0hVeTba20+qfSIic0WkWkSqd+3adRxJzw/BgSMGFIY4t7Q4J3OrPr9Vsyo8srKeub+sbu92Ez9vqzHGpEu25FQzRlUXAgvB9VPNcHIyJr4RE7hxhFu9LjixHP9kXt2wg+Xv72Dop4pAISTWqMkYk37ZElS3AmMCz0u8ZYm2iYhIATAYSJXN2OrtJ9U+TYA/243PD7Lvbdmbs91ugmLqiocBUCgZcjIbt++34l9jTNpkS/HvGmCCiJwpIkXAbGBp3DZLgdu8x9cDr2uK4aBUdRvwiYhUeq1+bwVeTH/S85ffUvjOiz9NDk/RmlTdroN88/m1LFrVmOmkGGPyRFbkVFU1KiJ3A68AYeAJVV0vIvOBalVdCvwM+JWI1AF7cIEXABHZDJwKFInITOAKVd0A/B3wc+BkXAMla6R0HMrLipl74TgeWVmf6aT0iid+/xFvbNzJjk+OcNN5pcyZXprpJBljclRWBFUAVf0t8Nu4ZfMCj48ANyR57dgky6uBKelLZf816ORCQpL7dauJ1O08QN3OAwC8F1nLC3+IMH7EIJu/1RjTY9lS/GuyXLB1cD4WBQet3tzMolWN3PTo29aX1RjTIxZUTbf4rYNvmlbK6YMGZDo5fSIag0ff/NAGijDGdFvWFP+a3PBcbYSjrbk5TvDxWLZhB8s27KAwLNxQMYbJNperMSYFC6qm24JTxwkw4tQB7D7YQiymiAio0pZnda7+4bS0KU96rYQFCIeE+TOmMHHkIJvH1RjTzoKq6bbg1HGFBSEW3FIO0B5UnquNtAeefKa4cYa//cJaJCS0tSmFYWHx3PMtsBrTz1lQNd2WaOo4f7nvmZpIzk4j11Nt6v/jcrLzf7OeeV+0WXKM6c8kxfgJ/U5FRYVWV1dnOhk5raahmedqI+zafxQFXv/TTtrysR9OEicV2iD9pv8RkRpVrch0OrKB5VRNWgWHOlywoo7leTC8YU/4g/RbUDWmf7IuNabXVI4byoDC/nWKhUJig/Qb04/1r18806f8OtjPlgzOdFL6TKwfFXUbYzqzoGp6VXlZMfO+OJmigv5xqimuNXRNQ3OHQSPinxtj8pPVqZpeV15WzOI7XKvh/YdbWb/tEwRYuWl3ppPWKzbt2M+Pln9Aq9fV5oG/nML8l9bTEo1RVGANmYzJZ/0j+2AyrrysmMpxQ/n5O5v5fd1uVm/ew1cuGke+DSMcU3jh3Y9paVMU19Xmid9/REs0RkyPNWQyxuQnC6qmz/gjMvnBZdDJhVw2aUSmk9XrPtx5gHBI3EhM4RCV44ZacbAxecqKf02fiR+RqXLcUCrHDeX193fk3fCGQQpEvQOMqfLwy+9T27gXVbXiYGPyjAVV02eSjcj04MxzmPfiOmKqFISEVq/oNJ/4xxNtU9ZsPpY7bbF+rcbkFQuqpk8FB4fwzZle2mFg+mXrt/PIyvr29SEgXwc+DIn1azUmn1hQNVkhGGzLy4opHfop/n3FJiJ7j+RtQBWB2y8403KpxuQRC6omK00cOYiP9x3JdDJ6lSr8/J3NlA79lM3RakyesKBqslJVfRP9Ya6HI60x7n9hLSgMsMH4jcl5WdOlRkSuEpGNIlInIvclWD9ARJ721q8SkbGBdf/sLd8oIlcGlm8WkbUi8q6I2PQzOWT/4VYkQSfWUwaE+z4xvUzVNWQ60hrj0Tc/tK42xuSwrMipikgYWABcDkSANSKyVFU3BDb7MtCsquNFZDbwXeAmEZkEzAYmA2cAy0XkLFVt8153qarm59A9eWrRqsYODZXCIUFVEREOt7SleGXue3XDDpZt2GG5VmNyVLbkVKcBdapar6otwFPAjLhtZgC/8B4/C3xeRMRb/pSqHlXVj4A6b38mR728bluH52cOHUhIhLaY5nV/Vp+fa73nqT8w4ydvsWhVI2DjBxuTC7IipwqMBrYEnkeA6cm2UdWoiOwDhnrLq+JeO9p7rMCrIqLAo6q6MP6NRWQuMBegtLT0xI/EnLCrp4zid4FxgccNP4X63QczmKLM2Np8mK3Nh3kvspb/XreN1Zv32PjBxmS5bMmp9pYLVHUqcDVwl4hcFL+Bqi5U1QpVrRg+fHjfp9B0Mmd6Kd+59hwunDCM71x7Dnde/GmKCkKEBYoKQlw+aQRFBSFCAgUhYea5Z+TdGMLxVm7azZFWGz/YmGyXLTnVrcCYwPMSb1mibSIiUgAMBppSvVZV/f93isjzuGLhlb1xACa95kwvZc70YyUH8SMx1TQ0d3h+qKWNVzfsyGCK+45NhG5M9sqWoLoGmCAiZ+IC4mxgTtw2S4HbgHeA64HXVVVFZCmwSET+L66h0gRgtYh8Cgip6n7v8RXA/L45HJNu8SMxxT+/8+JP88YHu2iJ5utQEce0tSnP1UYA2j+D+JsMY0xmZEVQ9epI7wZeAcLAE6q6XkTmA9WquhT4GfArEakD9uACL952vwY2AFHgLlVtE5ERwPOuLRMFwCJV/e8+PzjTJ/w5W5fURli8ujGv+7jGcC2kl9RGePL2SgBuebzK6luNyQKi+fzr00MVFRVaXW3dWXONn0srHlhE86EWNu3YzwvvfpzpZPW6EDB7eilb9hzirU27USAs8LUrJnLXpeMznTzTj4hIjapWZDod2SArcqrGHK+ahmZuebyKo60xFAh5jZm+ctE4Xnh3K9s/OZrpJPaaGLB4VWP7DDgC7VPqGWMyI99b/5o850987geWmLrp1NZv+4R7Pn8WBXl+hseXM33p/LFU1TdZX1ZjMsRyqian+ROft7TGiOFyazGFtzbtZs3mPcyfcQ4rNu7ko90Hqd95IG9nvAEXYBeurCeGKwZ+cOY5HVpQG2N6X57fx5t85098/vUrJ/Kda8/hggnDEFyAaY3GaD7UwmO3VnDtn43Ou4nPE/FvGtoUvv3iuvYcq43GZEzfsJyqyXnB7jUTRw5izeY9tEZjHeoXK8cNZUChy9EiLjeb79piyg+Xf8DVU0Yx/6X11jrYmD5grX8DrPVvfkjWZzPYSnj+S+tpjcYIhYTBAwtp2t+StznZELTfSFjrYNMbrPXvMZZTNXknfmCIRMsnjhzEc7URnl7TyO79LYCbDeeUAWH2HY72aXp7WwwQL6Ba62BjepfVqZp+qbysmDOGnExboOVSLKZMPzM/A44Cs6eVtg8WYfWrxvQOy6mafqty3FAKw0KLN59cYUGISyaezmt/2tEh2OaLD3bsZ/5v1rN+2yfEYmr1q8b0Aguqpt8qLytm8dzzWVIbQYBZU0uoqm/K2yEO12zumDP1Z7uxoGpM+lhQNf1aovrXooIQrdEY4ZBw7pghrN6cn8WkEhLe3bKX+59fy6ypJQA2KL8xJ8iCqjEBfr9XP7hU1TexZnNzXrYMjrYpy7zp8n5dvQUBojGlICTcUDGGWVNLLLga00MWVI2JE5979fu3+iM2hUJCW551dG1tO3Y8LW3aYRYcC6zGdJ8FVWNSCOZc/Vlwtu493GEg+3zkj0hlda7G9IwFVWO6EJ9zrWlo5tnqLe2thvOR4OpcX12/neKBRTaGsDHdZEHVmB7auH0/fjwN5emQh8UDC9lzqJX3Ivt4L7KWxqaD3HfN2ZlOljFZzwZ/MKYHahqa+fYLa9vrVPMxoALsOdTa4fmjK+tZtKoxQ6kxJndYUDWmB5bURuiq1Fekb9LSlxSYF5j1xhiTmAVVY3ogPl6GxP2FQ8K0scXcMr2UOy8cl5G09bZoTLl3yR8tsBqTggVVY3pg1tQSigpCCG6QiIdmnsPN00oJC1Q3NLOkNsL+o9FOwTdf1O08wE0L37HAakwSWRNUReQqEdkoInUicl+C9QNE5Glv/SoRGRtY98/e8o0icmV392lMT5WXFbP4jkq+ceVEFt9RyZzppZwx5GSiMSWmrhuK4nKuPsHlZvNFtE159M0PmfvLamb85C2razUmICta/4pIGFgAXA5EgDUislRVNwQ2+zLQrKrjRWQ28F3gJhGZBMwGJgNnAMtF5CzvNV3t05gei+9iUzluaPvQhoUFIa6bWsKUMwYz78V1buD6whBXTR7Ji+99nDfjCr/qjcQE8F5kLYB1uzGGLAmqwDSgTlXrAUTkKWAGEAyAM4AHvMfPAj8REfGWP6WqR4GPRKTO2x/d2KcxJyx+aEM/6E4cOYiq+ib2H25l4e/q8yagJvL0mkaaD7W0z9VqYwib/ipbgupoYEvgeQSYnmwbVY2KyD5gqLe8Ku61o73HXe0TEZkLzAUoLbU7bXN8Eg3M7z+/8ZG387brjW/dx/tYu3UfBeEQqBK1qeVMP5U1daqZoqoLVbVCVSuGDx+e6eSYPFLT0Mz836zvsgtOPmiL0V6n3NJ2rH65qr4p00kzpk9lS1DdCowJPC/xliXcRkQKgMFAU4rXdmefxvSKmoZmbnm8ivci+zosnza2mJMKQ4Slc/ecfBC8f5CQtBcHG9NfZEtQXQNMEJEzRaQI1/Boadw2S4HbvMfXA6+rqnrLZ3utg88EJgCru7lPY3pFVX0TLdFYh2VFBSHuvfpsnry9ktnTSglly9XXS9ralI3b92c6Gcb0qayoU/XqSO8GXgHCwBOqul5E5gPVqroU+BnwK68h0h5ckMTb7te4BkhR4C5VbQNItM++PjbTPwVbBIfDIa4vL+G6wPykVfVNHRouTRtbTHVDc17VvfqjMIGrcxWwOVpN3hPN5yaJPVRRUaHV1dWZTobJEzUNzUlbwfrFw343nCdvr2Tj9v188/m1GUpt7xGOFQsXFYRYfIc1Xso3IlKjqhWZTkc2yIqcqjH5KFGL4OC6RN1wnv9DhDWbO45WFAxKuSiY9pZojCW1kU5T6VkXHJMvLKgakyGJgu59V5/NjY+83d5iWIDCglCn+tlc9tTqRqacMZiJIwexpDbCszURom0x64Jj8oIFVWOyTDgcIhaNEQ4LN1WMQYHFqxpzOrcaFFP45vNrCXtz0frH5XfBsaBqclmetz80JrdU1TcRbXPjB2tMOWPIyVw3tYQBhfl3qbYFAqqfI7cuOCbX5d+VakwO81sNh+VYkPHrX2+ZXko4D6/YsMD/KBnMvC9MtlyqyXlW/GtMFknUgMlfXl5WjELezQrTpvBeZB/vb1/PxJGDLLCanJaH973G5LbysmLuunR8wuBy3dQSTioM5eVoTC3RGM/VRjKdDGNOiAVVY3KIn5O9eXpp+2TpPiH3hz7Ml8ZYpv+y4l9jslx8P07/77qpJe1Tyz3+1kdE82A4pl37j1LT0GxFwCZnWVA1Jov5Iy+1RDv34/SD64IVdcQCI6Pl8mARyzbsYMXGndxYMabDsI42QITJFRZUjcli/sD8wanU4oOK32K4JRpDcMG2dsteojk651y0TVm0qpHnaiM8eXslQNIbC2OyjdWpGpPFEnWxiVdeVsy8L0wmJEJMobZxL7E8KApuaY1x75I/cteTNRxtdTcWLa0xfrj8A2oamrvegTEZYDlVY7JYsi428ZoPtRBTRYFYTAmFBEEREdpimpPFwTGgbueBTst+X7ebNZv3WI7VZCULqsZkuVQD8/uCU80VFoSY94XJNB9qoXhgEfNfWk9r1I3SlMsZ2CEDC/nkcKvLsUZdjvWrl51lgdVkFQuqxuSBVDnaiSMHUVXfRPHAIv5l6Tpac7SudXbFGH7+zub2Oua3NlmO1WQfq1M1Jk8kGjQi2Gp2zvRSbqgYk5N9WYefUsQnR6PM+8Jkzhk9GHAtnIN1rDUNzSxYUWf1rSajbJLyAJuk3OSTRN1xgPbJ0UUgF2eUC4egLZBuAUICEhJiMbUWwhlgk5QfYzlVY/JUsu44T95eydeumMjnPjMi00k8Lm1xNwKKGz842qYdjtWYTLCgakyeStYdxy8mHj5oQIZTmH4CIMKbG3dy//NrrSjY9LmMB1UROU1ElonIJu//hGU2InKbt80mEbktsLxcRNaKSJ2I/FhEvOtKHhCRrSLyrvd3TV8dkzHZIJgrTVQcOmtqSafxg3NZSFxQbYspqzc38+SqRm589J28m9XHZLeM16mKyPeAPar6sIjcBxSr6r1x25wGVAMVuNKeGqBcVZtFZDVwD7AK+C3wY1V9WUQeAA6o6v/pblqsTtX0N35DpuKBRTQfamH/4VYW/q4+J7venPapQvYcbO20vCAkPH3n+VbH2ousTvWYbOhSMwO4xHv8C+AN4N64ba4ElqnqHgARWQZcJSJvAKeqapW3/JfATODl3k60MfkgUR/YyyePZElthJUbdxLZeyRDKTsOSW4E2mKacHhHY3pDNgTVEaq6zXu8HUjUemI0sCXwPOItG+09jl/uu1tEbsXlcr+uqlbBYkwX/EDrtx5u9ZoIZ3v31j2HOudSwcXa97bsba9ftYH5TW/qk6AqIsuBkQlW3R98oqoqIum6dH8KPIi7ph4Evg/8TYK0zQXmApSWlqbprY3JfcEBJfYfbuWRlfWZTtJxW7ZhB69v3IkqqFq3G9N7+qShkqpepqpTEvy9COwQkVEA3v87E+xiKzAm8LzEW7bVexy/HFXdoaptqhoDHgOmJUnbQlWtUNWK4cOHn+ihGpNX/JbCg04uJJSkRVMuTI6uuC43bTFtH+bQut2Y3pDx1r/AUsBvzXsb8GKCbV4BrhCRYq918BXAK16x8SciUum1+r3Vf70fqD3XAut66wCMyXd+95z44Hne2GL+9dpzCIezPax2FBJJOOOPMScqG4Lqw8DlIrIJuMx7johUiMjjAF4DpQeBNd7ffL/REvB3wONAHfAhxxopfc/ravNH4FLgH/roeIzJO35R8AUThrUvCwETRgzi5XXbcmqquZDA/BlTrOjX9IqMd6nJJtalxpjUgo2XwiEBEVq8hkwChEJuqrlsFRJ4aOY5zJlu7SfSybrUHJMNOVVjTI4IDihxQ8WY9pbBACIwtXRI5hLXDRNHDGLdx/tspCXTayyoGmN6xG+8NGtqicutBpw1YhBFWVy/+v72/Sxa1cj1P32bGx9524KrSTsLqsaY41JeVsz8GVMoCAkhgaKCELOmlrB47vl8tmRwppOXkgKrNzdzwyNv880EYwTbNHLmeGXD4A/GmBw1Z3pp+yTowQEVRpx6ErAvs4nrhpjColWNPFu9hRsqxjBrquuhFz9lnjVqMt1lQdUYc0ISDXU4LMdmwGlpU55c1cgz1Vu4vmJM+5R5R1tjLKmNWFA13WbFv8aYtLtuaglFYUGAghB8tmRw1g8QAS64rq5vIuTVFSvwbE3EioFNt1lO1RiTduVlxSyee357sTC4ItUjrR1nGL9owjDe/rCJaBZ1w6nbdZBgW6u2tpgNyG+6zYKqMaZXxBcL++MIb9qxn3e37OWqySO575qzWbSqkXkvrsuqwBpTN2VcTBURoXhgEXBsqjwbkN8kY0HVGNMnEtW9AjQfaiGWhYPQTC0dQk1DM20xZf5L6wGY/9J6a8BkUrI6VWNMRhUPLCIkQgjXLScburn6XW7a1D1ujcZ4ed229gZMrTYgv0nCgqoxJmNqGpqZ/9J6YqqEQsIDX5zMgzPPyapGTQIUFoS4esqo9qBfWBCyAflNQlb8a4zJmKr6pvbcn6A0H2rhrkvH09h0MGvmbz1vbDH3Xn02ABdNGM6OT45w03ml7UW/Vs9qgiyoGmMyxp9SrjUa65D7u+8aF8SyIbCu3tzMsvXbeeL3H9HS5up+N2xbR2PTQd6pb2L9x/vcTYEIn/vM6Xzl4k9bcO3HbJaaAJulxpi+lyynV9PghhHMhkbBA4tCHG6J0Z2kFIWFxXPP71eB1WapOcZyqsaYjErWKriqvikrAirAoZZY1xt5WtvU+rX2Y9ZQyRiTlfyi4XiFYeHySSOYNrYYyaYWTZ7CsFgjpn7McqrGmKxUXlbM4jsqea42ws79RxFg+KAB7YPe3/ToO2RL7dUVk0YwfNAAFDdEo+VS+y8LqsaYrJWsaHjBijrasqVsGHhj404e+MspNB9qYeP2/dYauB+zoGqMyTmV44YyoDBES2uMUEj4s9IhVG9uRnH9SkXo0/rYaEyZ9+I62mLanoZwSJg/Ywpzppf2XUJMxllQNcbknPKy4vaxhIMD9rdGY4hInw97qArRwHsqLtB++4W1rP94H7OsSLjfyHiXGhE5DXgaGAtsBm5U1U7zLInIbcC3vKcPqeovvOX/CtwKFKvqKYHtBwC/BMqBJuAmVd2cKi3WpcaY3OV3zSkeWMT8l9bTGo2BCCFxLXIzqaggxOI78nesYOtSc0w2BNXvAXtU9WERuQ8XHO+N2+Y0oBqowN0E1gDlqtosIpVAA7ApLqj+HfA/VPUrIjIbuFZVb0qVFguqxuSHYIC9//m13epfmi7hELQl6IFzxaQRLLw1P+OOBdVjsqFLzQzgF97jXwAzE2xzJbBMVfd4udhlwFUAqlqlqtu62O+zwOdFsrEBvjEm3crLirnr0vE0H2rp04AKiQMqwPL3d1DT0ExNQzMLVtTZxOd5KhvqVEcEguJ2YESCbUYDWwLPI96yVNpfo6pREdkHDAV2BzcSkbnAXIDSUmtQYEw+qRw3lKKwtA8vmEkxhXuffY+Pdh8kpjCg0KaPy0d9ElRFZDkwMsGq+4NPVFVFpE/PflVdCCwEV/zbl+9tjOld5WXFLJ57PktqI+zefxQFVmzcSdQLsgJ9mpOt23Ww/fHR1piNvJSH+iSoquplydaJyA4RGaWq20RkFLAzwWZbgUsCz0uAN7p4263AGCAiIgXAYFyDJWNMPxLf17Wmobk9yAK89v4OMpGRVWD/4VYWrKijeGARzYdarG9rHsiG4t+lwG3Aw97/LybY5hXgOyLin21XAP/czf2+A1wPvK6ZbpVljMkKz9VGaInGCIm051QFuGzSCASo3ryHPYdaez0dj731EarqTX1nRcL5IBsaKj0MXC4im4DLvOeISIWIPA6gqnuAB4E13t98bxki8j0RiQADRSQiIg94+/0ZMFRE6oCvAff14TEZY7JUcA7XWEwJibiJx8PCvkMtvLphR58EVIC2mLYPUqFAa9QVCZvclfGcqqo2AZ9PsLwauD3w/AngiQTb/RPwTwmWHwFuSGtijTE5L34O13lfmMy6j/fxbE2E1ZuTt8gVcbmQ3iwq9ouETe7KhpyqMcb0GX80pq9dMZEnb69kzvRSBJdLjBfsgxcWeHDmOVw+KVEHhZ4Lh4T4Pn4xdROzL1rVmJb3MH3Pgqoxpt/x+7GWlxVT09DMM9Vb2utWwyFhdPHJQMeWwaqw7uN97PzkyAm/f8mQkxh56gCX+/X+gl5el6jrvckFGS/+NcaYTKqqbyIaO9bF5qbzxrBlzyG2Nh/utO1TqxvTMlB/ZO+xwCwCpcUDadhzqH3Z1VNGnfibmIywnKoxpl/z61jD4lrfXje1JGFQa9PemflGlQ4B9aIJw2xmmxyW8bF/s4mN/WtM/+SPFRzsJ7poVSMLV35IQ9Ohbg0QEZb0NWKaNraYe68+uz0tidKXTWzs32MsqAZYUDXGBNU0NHPTo++0Fw+nMrr45IRFxkE9GcFJBO68cByXTx7JLY9X0RKNURAOcX15Cddl2VRyFlSPseJfY4xJorysmPkzpnT6oQyLNxk6LpgWhoWPEwTUcHwLpB5QryXwo29+2N6vtiUaY/GqRm55vMoG5M9SFlSNMSaFOdNLuTmujjOGy3EWFoS4+KzhtMUUxQVZvzXvSYUh7rjgTMaffkr7skKv7rYn6ncfpCB87KfaBonIbtb61xhjujBraglLvKENY+pykQDRthgCnQaTaD7UQvHAIh5Yuo7WNiUcgpvOK2XW1BLm/2Y970X2ddh/qmLh0wYWsrmp49pwOETluKFpP05z4iyoGmNMF/wBI364/AN+t+nY7JEhEWZNLWHW1JJODYm++fza9innojHYtf8oVfVNnD9uaKegmiyghgSGDCxqn1XH19YWY9n67VndeKm/sqBqjDHdUF5WzFcvO4s1m/fQ0hojFBLmz5jSPoBEvPhS3tfe38Hy93dQ4I2k1FWDJRGYe+E4Pjka7bSuzatvFVy97fwZU6wbTpaw1r8B1vrXGNOV+O4tNQ3NCVvnAtz8WBWt0Rgix/q49qQFcFhg4shBbNi2P+V2BSHh6TvPz1iO1Vr/HmMNlYwxpgeCQxxCx1lvgq1zARbfUenGCg5E0XBYKOxma6U2pcuAChCNKY+++WHPD8aknQVVY4w5Af6ITH6YjG+d+/qfduIP1S/ApRNP54aKMVwxaQSXTxrRadzfRGMB+wpCwlcuGsdnSwZ3Wvfqhh02EH8WsKBqjDEnwG/ENGd6KUVhb27WAtc6t6q+iVigii0k8OYHu3hqdSMrN+3iKxd/mme+8j+5YtIIxp9+CldMGsFDM88hFBdVC8PCnOmlPH3n+dx3zdlMHt05qIINxJ8NrKGSMcacoPKyYsrLihO2Ai4qCNESjRES4XOfOZ3l7+8gpsdys3ddOp6Ftx6rjlywoo5YYASnz5YMZt4XJ3eoL71uaglPr27sNCzi5FGn9u6Bmi5ZUDXGmDTxg2vw+ZO3V7YHWoCVm3a192mtHDe0U8OnTpOoxwXU4L7jJ1UfdHJh7x6g6ZIFVWOM6UXxgTY+yPoth4sKQjx5e2WnQBwfUP3WxkdbO06qXhASGxAiC1hQNcaYPhQMsgtW1LW3HPaLg/31ybrH+K2NgyW/IaG9z6zJLGuoZIwxGRKcy9UvDu5K8cCiTgNLxE+iU9PQzIIVdTbofgZkPKiKyGkiskxENnn/J7zVEpHbvG02ichtgeX/KiJbRORA3PZfEpFdIvKu93d7bx+LMcb0hF/U+7UrJrYX/aZS09DM/JfWJ5y39ek1je3b3PJ4Fd9/daPNZpMB2VD8ex/wmqo+LCL3ec/vDW4gIqcB/wJU4LqB1YjIUlVtBn4D/ATYlGDfT6vq3b2aemOMOQGpinqDahqa+eHyD2iJxhKuX7/tExatauTldds6FSkDNk5wH8mGoDoDuMR7/AvgDeKCKnAlsExV9wCIyDLgKmCxqlZ5y/oircYY0+uSDYV4tNXVpYbENUw6fdAAInuPABBrU+a9uK59Gjp/qrnigUUJG0OZ3pENQXWEqvo9lrcDIxJsMxrYEnge8ZZ15ToRuQj4APgHVd0Sv4GIzAXmApSW2oDUxpjMCo4l7AfBYOOkEPDn44fx1cvOAlzrYTe+sBBT7bRNcBjFYGMo0zv6JKiKyHJgZIJV9wefqKqKSLpG+P8NLid7VETuxOWCPxe/kaouBBaCG1A/Te9tjDHHJVEQjO+7+tXLzmoPjH7QLR5YxPyX1ifcJvha63bTu/okqKrqZcnWicgOERmlqttEZBSwM8FmWzlWRAxQgismTvWeTYGnjwPf63aCjTEmQ+IDqF8EnKzvarBOduLIQe0BdklthOdqI8yaWpKy36tJr4xP/SYi/wY0BRoqnaaq/xS3zWlADTDVW1QLlPt1rN42B1T1lMDzUX6xsohcC9yrqpWp0mJTvxljskF8nWpPX3vzwnfaJ0gvKgix+I7erUe1qd+OyXiXGuBh4HIR2QRc5j1HRCpE5HEAL3g+CKzx/uYHGi19T0QiwEARiYjIA95+7xGR9SLyHnAP8KU+PCZjjDlu8dPL9URVfROtgT43wRbApvdlPKeaTSynaozJdZZTzaxsaP1rjDEmTcrLilk893yW1EYQYNbUEqtH7UMWVI0xJs90d0AJcDlbC8DpY0HVGGP6qfii4mdqIr1eVJzvsqGhkjHGmAywRk3pZ0HVGGP6qcpxQykMHxvi1QaHOHFW/GuMMf2UNWpKPwuqxhjTj/WkUZPpmhX/GmOMMWliQdUYY4xJEwuqxhhjTJpYUDXGGGPSxIKqMcYYkyYWVI0xxpg0sVlqAkRkF9BwHC8dBuxOc3JykX0O9hmAfQa+/vQ5lKnq8EwnIhtYUE0DEam2aY/scwD7DMA+A599Dv2TFf8aY4wxaWJB1RhjjEkTC6rpsTDTCcgS9jnYZwD2Gfjsc+iHrE7VGGOMSRPLqRpjjDFpYkHVGGOMSRMLqidARG4QkfUiEhORirh1/ywidSKyUUSuzFQa+5KIPCAiW0XkXe/vmkynqa+IyFXed10nIvdlOj2ZIiKbRWSt9/1XZzo9fUVEnhCRnSKyLrDsNBFZJiKbvP9tfrV+wILqiVkHzAJWBheKyCRgNjAZuAr4dxEJ933yMuIHqnqu9/fbTCemL3jf7QLgamAScLN3DvRXl3rff3/qo/lz3LUedB/wmqpOAF7znps8Z0H1BKjq+6q6McGqGcBTqnpUVT8C6oBpfZs604emAXWqWq+qLcBTuHPA9BOquhLYE7d4BvAL7/EvgJl9mSaTGRZUe8doYEvgecRb1h/cLSJ/9IrD+ktxV3/+vuMp8KqI1IjI3EwnJsNGqOo27/F2YEQmE2P6RkGmE5DtRGQ5MDLBqvtV9cW+Tk+mpfo8gJ8CD+J+WB8Evg/8Td+lzmSBC1R1q4icDiwTkT95ubh+TVVVRKz/Yj9gQbULqnrZcbxsKzAm8LzEW5bzuvt5iMhjwEu9nJxskbffd0+p6lbv/50i8jyuaLy/BtUdIjJKVbeJyChgZ6YTZHqfFf/2jqXAbBEZICJnAhOA1RlOU6/zfjh81+IacvUHa4AJInKmiBThGqktzXCa+pyIfEpEBvmPgSvoP+dAIkuB27zHtwH9rmSrP7Kc6gkQkWuB/wcMB/5LRN5V1StVdb2I/BrYAESBu1S1LZNp7SPfE5FzccW/m4E7M5qaPqKqURG5G3gFCANPqOr6DCcrE0YAz4sIuN+WRar635lNUt8QkcXAJcAwEYkA/wI8DPxaRL6Mm1Lyxsyl0PQVG6bQGGOMSRMr/jXGGGPSxIKqMcYYkyYWVI0xxpg0saBqjDHGpIkFVWOMMSZNLKgaY4wxaWJB1RhjjEmT/x9HQg8+RCEgZgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.plot(sklearn_pca_results[:,0],eigengame_pca_results.reshape(-1,),'.')\n",
+    "plt.title(\"Correlation between NumPy-calculated PC1 and EigenGame-calculated PC1\")\n",
+    "np.corrcoef(sklearn_pca_results[:,0],eigengame_pca_results.reshape(-1,))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 1.        , -0.94687302],\n",
+       "       [-0.94687302,  1.        ]])"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjsAAAEICAYAAAC50DXFAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/NK7nSAAAACXBIWXMAAAsTAAALEwEAmpwYAABGzElEQVR4nO3de5ycdX33/9dnZnYCm8BmSUhCwibrCqshRneTzUFqKioi0iraiqVSjNBAbUvbm9pWLdLbn0hvD0VqD7dKuMGIIAJWoWpRKUKjmIRNdiXEQAjrhiXnhM0GsjFzuL6/P65rlmsnM7Ozp5nZ2ffz8djH7lzH7/c6zWe/h+trzjlEREREqlWk3AkQERERGU8KdkRERKSqKdgRERGRqqZgR0RERKqagh0RERGpagp2REREpKpVfLBjZh8xs5+NYv3/MrPVY5mmYLtfN7PPjvV2pTzMrNHMnJnFRrmdkl0Xo703ZPyZ2WNmtmaE675iZk1jnabJYjTHPrSNC8zsxbFKUxH7c2Z2Tqn2N5kUFeyY2YfMrD24+fYGAcRbxjtxw2Vmnzazb4anOefe7ZxbV6405TIRAqXgQfEbM2sITbvQzLrHaX+fNrNkcI0dMbMnzOzN47GvSjEWD2M52VgFruMt65rP/BzJzHfOTXPOdZUgHWZm15nZU2bWb2b7gmvz8vHedzXRPx/jZyyelUMGO2b218A/A/8IzAbmA/8XuHS4O8v18Kn0B9Ikdwy4sYT7+7ZzbhpwJvAz4D/MzEq4f5FS+3YQ1GR+ppchDf8C/C/gY8AMYB7wKeDiMqRFZHw45/L+AHXAK8BlBZaZgh8M7Ql+/hmYEsy7AHgR+DiwD7gL+DTwAPBN4CiwJtjP/wP2AruBzwLRYBsfAX4W2t+XgZ5g3c3AqmD6xUACSAZp/mUw/TFgTfB3BP8m3gUcAL4B1AXzGgEHrAZeAA4BNxTI99eBrwI/AV4GHgcWhOa/Ppj3EvAs8MFg+rVBGhNBOv8TuAr4z9C6zwH3hz73AC2Fths6F/8UpH9/kL5Ts87Fx4K87wWuKpC/x4D/HeTttcG0C4Hu0DIOOCfrmHw2a39/F9rf+4BLgB1B+v8+tO6ngW+GPi8Ktj8rWHZxaN4soB84M0/a3wI8ARwJjt1Hgum/A3TgXzs9wKdD62TOfyz4fAZwJ/413Qt8L9f1mH0cso5BPfB94GCwje8DZwfzbgbSwG+C6+Dfiji/M4CHgvRvAm7KTkuRx6EO/9o/iH8vfAqIhPL3c+DWYL0u4Pxgek9wLlcP4z44H3gS6At+n591jd0U7O9l4MfAzND8laH0/xK4oJh18a9/FxzXV4A3A+cEaevDv7e/XeC43Y//vOoD/gdYlJXffwd+EOx3I8H9Ecx/J/BMsO6/Bftck2c/nyZ0zeeYH76uZuA/K44Gx/GzDH4uFrpu8qYZaMa/DtuG+C64CtgerN8F/Elo3gUM716PAJ8AngcOA/cBZxTYd757Me/9lf3sDz5fE8rDr4AlxT7HQvMy6c5s4/3B9IX493Ia/5o7MtQzOZj/t8Hx2gNcnZ2WYo5DKG87g2P9EDA36zr6M/zvlZfx75vX4t9bR4PjH886l3+Pf590A1eEtjXUs+NnQX57gV8D785at+D3fK51yfGsBAz/GXUgyMNW4A0Fr+EhLvCLgRTBF0CeZT4DbMD/AjozOIA3hQ5cCvh8cNJPxb/Bk/g3QySY9l3ga8DUYDubCG4mTg52/gj/xo/hf3HvA07J9/BgcLBzdXBBNAHTgP8A7grmNQYXxdogTW8CTgAL8+T768GF89tB3r6cSWeQjx78B0QMaA0unPOyb6bgcxP+Az0CzMW/iF4MzesN5g213VvxL/QzgNPwH47/J+tcfAaowX8Q9QP1efL3GH4g+qXMMWX4wU4K+Idgf9fg3yD3BGlbBBwHXpN97oLj+UXgheDz/wU+H9rPXxEKDrPSvSA4L38Y7HcGrwaKFwCLg2P5RvyHz/uyzn8m2PkB8G38B2oN8NZc12OOL6XwMZgB/D5QG+T5fgY/oB5j8MN4qPN7L/6DaSrwBvwHRs5gZ4jj8A3gwSBNjfhfSH8cyl8qSEMU/4H0Av6X5RTgomC704q4D87Av3avDPLzh8HnGaH8P4//hXtq8Plzwbx5+F+ElwTn653B5zOLWHfQuQymfQu4IdjWKcBbCjzTrg6OTeYfuc6sa/wwsDzI093AvcG8mcGx+EBwzK8PjuVYBDv3Bj+1wHn418lwnjf50vxRQvd0gbT8Dv4XpAFvxX92ZIKFCxjevf5X+N8ZZwfH+GvAtwrsO9+9WPT9BVyGf78sC/JwDkFQzvCCncvwn9ER4A/wS7/PKvBsKPRMvhj/GfSG4Bzek52WIo/D24PzvSQ4nv8K/E/WdfQgcHpwLk4A/43/3VKHH7StzjqXXwq29dYgj68r8tmRDM5/FPhT/MDMgvlDfc8XWnfgXAaf34Vf2DE9OJ8LM+ch73U0xAV+BbBviGWeBy7JSkR36MAlCIKR0A0ePhGzg4Mfjnb/EPhpvgsoa/+9wJvyPTwYfMH/N/BnoXmvCw5wjFcfkOH/DDYBl+fZ79cJHhjB52n40WcD/k2wPmv5rwH/O/tmCs3vwb9YLwduC/b9evwH2EPBMnm3G5zwYwz+L/PNwK9D5+I4g78ADgAr8+TvMfxg50z8/1IXMfxg5zivRu6nBcuvCC2/mVeDjU8H18qRIF2PAkuDeSvwv3AzF347of9cs9L9SeC7ha7Z0LL/DNwa/J05/zHgLMAjRyDIMIKdHOu2AL25rs0izm8U/1p9fWjeP2anZajjEGwnQfBFGEz7E+CxUP6eC81bHORvdmjaYV4NnL5O/vvgSmBT1v5/waslTI8BnwrN+zPg4eDvjxP8IxKa/yNefSgXWnfgXIbmfwP/vjo7+5gMcY1MD7ZVF8rv7aH5lwDPBH9/GNgQmmf4/yUXCnYy13zm56fZ11Xo3L8uNG+gZKfQdVNEmj8VTnMw7cUgLb8hVEqXtcz3gL9yI7vXtwPvCM07K8jfSf9UU+BeHM79FVw7f5VnvaKDnRzrdgKXhu6d8D/mQz2T7yAI0IPPzdlpKeY44JeWfCHrHkwCjaH8/VbWufh46PMtwD+H8psCpobm34ffnKGYZ8fO0LzaYN9zKO57Pue62ecy+Px2/EBrJUHJ0lA/Q7WXOQzMNLOYcy6VZ5lMSUTGrmBaxkHn3G+y1ukJ/b0AP0rdG2qeEclaZoCZ/Q3wx8E+HH60OnOIfBRKawz/RGTsC/3dj3/h5DOQRufcK2b2UrCPBcCKcGPDYD93FdjW4/gXWqa4/Qh+VP3m4DNDbPdM/Atkc+g4Gv4FmnE46zwOlT+ccwfN7N/wS4S+UmjZHA4759LB38eD3/tD849n7f8+59wf5UjDRjPrBy4ws734x+gh8HushBY9D/9L9vlciTGzFcDn8P+TiuP/53J/jkUbgJecc72Fs1eYmdXi/2d3Mf5/YwCnmVk0dFzChjq/MQbfF+FrOVu+4zAT/37Lvg/mhT5nnyOcc4XOW777IPt+y7WvfPfbAuAyM3tPaH4N8NMi1s3l7/CL7zeZWS9wi3PujuyFzCyKX2x+Gf4x94JZM/GD/kL7ncvgY+HMLOdzLCTnNZ8l17nPfoYO9bzJl+bD+F+kA5xzZwdtKZP4zxDM7N34QXcz/vO5Fr/qIGM49/oC4Ltm5oXmp4HZZnYjfuk9+MH8I+S5F4d5f+V9LgyHmX0Y+Gv8gBr8POX7/hnqmTwXP/DIGOp+zvdMmgtsyXwI7sHD+PdZdzA5+1xkf54T+tzrnDuWla65FPfsGLjOnHP9Qb6n4ZdsDfU9n2/dkzjnHg2+l/4dWGBm/wH8jXPuaK7lMzsr5Bf40dj7CiyzB//izZgfTBtIV660hv7uCfYx0zk3Pfg53Tm3KHslM1uF/9D6IH6EOx3/AZQ5ern2NVRaUww+8cMR7qmUOaF78PP0eCg/053f+PBPC6QzE+ysCv5+HD/YeSuvBjuFtnsI/6JdFJpX5/wGv6P1ReBtwNKs6f34N3PGHMbPOvyH4JXAA5kA2g1u3PkC/jF6bZ5t3IMfJDU45+rw689zNYDuAc4ws+k55h0jlGczK5Tnj+GXHq5wzp2OX9UD+a/XQuf3IP612hBafn6Bfec7Dofwv8Sy74PdBbY1lHz3Qfb9Npx99eCX7ISPxVTn3OeKWPek+8s5t885d41zbi7+f6P/N08X3w/hd764EL+IvzGTtSL2u5fBx8IYfL5GKnPuzw5NC293qOdNIY8CZ5tZW74FzGwK8B389hSzg+fuDynumOTSg98eI5zeU5xzu51zHw3dz/9I4XtxqPsre5/5ngtFPcfMbAF+M4fr8KtipwNPk/9+HuqZPOh6Yej7Od9xGHSfmdlU/Cq+kd7T9cE2wunaw+ieHUV/z+eR657+F+fcUvx/cpvx2z/lVTDYcc714dfD/ruZvc/Mas2sxszebWZfCBb7FvApMzvTzGYGy38z3zZz7GMvfuPCW8zsdDOLmNlrzeytORY/Df+mPwjEzOwf8Et2MvYDjWaWL1/fAq43s9cED+V/xG+omK/UaiiXmNlbzCyO/1/jBudcD35DuWYzuzI4XjVmtszMFobSmf3+jMfxA4pTnXMvAuvx/2OZgd+olkLbdc55+DfirWY2C8DM5pnZu0aYtwHOuSP4RZ1/lzWrE/iQmUXN7GL8wGy8fBN4P37A840Cy90NXGhmHzSzmJnNMLOWYN5p+P8d/cbMluN/sZ0kuCb/C/8LsT44zpkH6S+BRWbWYman4FdF5HMa/sPuiJmdgf+fcVj2dVDo/Kbx25h9OrgPz8NvTD+s4xBs5z7gZjM7LXiA/zXDuGdzyHcf/DDIz4eCNPwB/oPp+0Vs85vAe8zsXcH1dYr57zw5e8g1/eeDR+jYmtlloXV78R+eXo51T8N/KB/G/wL8xyL2l/ED/Gvj94KSkb9kDP4ByHHuX49fZZYx1POm0Lafxa/yutfM3mlmpwalW+eHFsuUgh4EUkEpz0WjyNJX8a+/BQDBd8eledJX6F4c6v4Kux34GzNbar5zMvun+OfYVPzr5mCQ7qvwS4kz9uMHjvEg7UM9k+8DPmJm55lfSpU3/UMch28BVwXPpCn41+xG51x3geMxlP/PzOLmFzD8Ln6HmRE/O4b5PZ/LoGdlcH2vMLMa/H9Af0Pu+3nAkF3PnXO34GfoU/gnuQc/sv1esMhn8dtQPIVfrLklmDYcH8a/oX6F/yB6gKyi1cCPgIfx6+p24WcwXAyWqZI4bGZbONkd+EW7/4Pf2vs3wF8MM61h9+BfoC/hl3r8EYBz7mX8h8Hl+BHxPl5tpA1+Het55r9P5nvBOjvwW5qvDz4fxe/18PNMkWwR2/04fgPsDWZ2FL8I+HWjyF/Yl/GLmsP+CngPfpXbFbx6TYy54MtzC/7DZn2B5V7Ab5PwMfzz0onf2Bz8dh2fMbOX8YPy+wrs8kr8/2KewW9D9L+C7e/Ar9J7BL93Q6H3avwzfuPZQ/gNMh/Omv9l4ANm1mtm/1LE+b0Ov1h3H367gjvz7XiI4/AX+A+IriD99+DfGyOV7z44jP+g/Bh+8PB3wO865w4NtcHgfF+K3ysk89z5W4p7ZvXjV0X9PLjHVuI3TN1ofrXnQ/jtN3K9w+Yb+M+W3fjPow1D7S+030P41V+fw8/vufi9xQr5Axv8np1XMl+MWa7DL2nK9Gr9Fn5QVsxzYSh/jt/9/Ev45/BF/KD1D/A7CbyMH7jdh/98/hBBNfIIfTlY/8fBvbgBv11ePjnvRYa+vwY45+7HvybuwW9E/j38Ekgo8jnmnPsV/j99v8D/8l3M4PP7KLAN2GdmmWs87zPZOfdfQR4eDZZ5NP8hAPI/kx7Bb1PzHfzSotfiXwsjtQ//PO/B/6fpo865Z4J5o3l2FPs9n8ugZyV+IcfaYDu78O+3LxbaQKbBp0jFM7M7gD3OuU+VOy3iM7Ov4zfg1DkpITP7PH7jzUKleyLDYmYX4HfyKaYEdULRC/1kQjCzRuD38LvVikwqQdVVHL/0fBl+Jw29fVukSBU/NpaImd2E3xDwi865X5c7PSJlcBp+u51j+O9auQX/fSciUgRVY4mIiEhVU8mOiIiIVDW12alSM2fOdI2NjeVOhojIhLJ58+ZDzrkzy50OGVsKdqpUY2Mj7e3t5U6GiMiEYmaF3mQsE5SqsURERKSqKdgRERGRqqZgR0RERKqagh0RERGpagp2REREpKop2BEREZGqpmBHxk7PJlh/i/9bRESkQug9OzI2ejbBuvdCOgHROKx+CBqWlztVIiIiKtmRMdK93g90XNr/3b1+VJvb19XH5oe72dfVN0YJFBGRyUolOxXEzF6HP6JxRhPwD8B04BrgYDD9751zPyxt6obQuMov0cmU7DSuGvGm9nX18eCtHaRTHtFYhEuvb2VOU90YJlZERCYTBTsVxDn3LNACYGZRYDfwXeAq4Fbn3D+VL3VDaFjuV111r/cDnVFUYe3e0Us65eEcpNMeu3f0KtgREZERU7BTud4BPO+c22Vm5U5LcRqWj0k7nXnN9URjEdJpj2g0wrzm+jFInIiITFYKdirX5cC3Qp+vM7MPA+3Ax5xzvdkrmNm1wLUA8+fPL0kix8Ocpjouvb6V3Tt6mddcr1IdEREZFXPOlTsNksXM4sAeYJFzbr+ZzQYOAQ64CTjLOXd1oW20tbU5jXouIjI8ZrbZOddW7nTI2FJvrMr0bmCLc24/gHNuv3Mu7ZzzgLWA+nSLiIgUScFOZfpDQlVYZnZWaN77gadLniIREZEJSm12KoyZTQXeCfxJaPIXzKwFvxqrO2ueiIiIFKBgp8I4544BM7KmXVmm5IiIiEx4qsYSERGRqqZgR8qqv6ODQ1+7jf6OjjHb5p4d29n43fvYs2P7mG1TREQmLlVjSdn0d3TwwlVX4xIJLB5n/p13UNvaOqpt7tmxnftvuoF0KkU0FuOyG29mbvPCgmno3/QktcuXjXrfIiJSmRTsSNn0b3oSl0iA5+GSST/oGGXA0bNtK+lUCud5pFMperZtzRvsjEewJSIilUfVWFI2tcuXYfE4RKNYTQ21y5eNanudBzrpOKUbi0axSIRoLEbDosV5l88VbImISPVRyY6UTW1rK/PvvGNMqpE6D3RyzY+vIZFOcNbyqXz0jD9g+fKLClZhZYItl0yOSbAlIiKVScGOjImRtn2pbW3NufyeHdvp2baVhkWLCwYsGe3720mkE3h47Jvez6E3TR1yvdrWVvr+7ZNseOYRVr7+QlVhiYhUKQU7Mmpj3fZloJFxMkk0alz20dXMXfX7Bddpm91GPBon6SWpidTQNnvooW06D3RyXfcXSdQk+GZ3B2ubm2mZ1TLidIuISGVSmx0ZteG2fek80MntW2+n80DnSfP2dfWx4Xv/QyqZxDnnNzK+/ybo2VRwmy2zWlh70Vqua72OtRetLSpoCZcGJb0k7fs1cKqISDVSyY6MWs62Lz2boHs9NK6ChlfHLQ23rYlH44MCk+7/epKHH+ojmZwKLoqRJGqOhlNf8rfVUHj805ZZLQWDnM4DnbTvb6dtdhsts1pGVBokIiITj4IdGbWTGhrPTMK690I6AdE4rH5oIFDJVZrSMquF/o4OnvnXe0k3XEwkNpf4ab/PvOgPWTn958w9LeEHTSEndh3lRFcfU5rqmLLg9CHTmC/IWnvR2kEBkIiIVB8FOzImBjU0Xn+LH+i4tP87VCqTrzSlf9OTTD/8DJF578QzqKk5i/M//JfMSbWdVDp0YtdRDt2+FZfysFiEmWsWDxnw5AuyhioNEhGRiU/Bjoy9xlV4kRiWdrhIjEioVCZfaUrt8mVM/8pXaN36bxw543W8/i8uZ86blwFvPmnzJ7r6cCkPHLiU55fwDBHsqMpKRGTyUrAjY27P8dNYv2sxc6ccZs+JGaw6fhpzQ/NzlaZkqsJmFtF9fUpTHRaLDJTsTGmqGzJNqrISEZm8FOzIiGQ39g3r2baV3cem8uLLp2KRSMEhG/Z19bF7Ry/zmuuZE1SF7evqY/vD3f60IJDp69tCb+9G6utXULdgCTPXLB7UZqenp4fu7m4aGxtpaGjIuS9VWYmITE4KdmTYCvWoAmhYtJhoLDYwGGdmyIbNu3rZ0HWYlU0zWLqgnn1dfTx4awfplEc0FuHS61tx+4+x7f7nOJjwaLduLr2+lVNnPM+WjivxvASRSJwlrXdRt2DJQNVVT08P69atI51OE41GWb16dd6AR0REJh8FOxXIzLqBl4E0kHLOtZnZGcC3gUagG/igc663HOnL19g3Y27zQi678eZBb0DevKuXK27fQCLlEY9FuHvNStjRRzrl4Ryk0x67Nu5j7taDNNcY59RE+UV/msef/gUvTH+A+uNJXjPFw/OS9PZupK5uycD+uru7SafT/nt50mm6u7sV7IiIyAAFO5Xrbc65Q6HPnwD+2zn3OTP7RPD54+Ox46GGfsjX2HdQyU3zwkFVVxu6DpNIeXgOkimPDV2H+f3mM4nGIqTTHtFohJkxw5zDzMA5jtV189W+fyfZmyRqcf7szCSvPTVGff2KQelpbGwkGo0OlOw0NjaOx2EREZEJSsHOxHEpcEHw9zrgMcYh2Clm6IdcjX1zldwsXVA/sM7KphnEYxGSKY+aWISVTTOYs6COS69vHWizUx81Dj110G94HIlw9M29JA8l8fDARemdupIlb/qzQaU6AA0NDaxevXrINjsiIjI5KdipTA74sZk54GvOuduA2c65vcH8fcDs7JXM7FrgWoD58+ePaMe5hn7IVbqT3dg3V8lNONhZuqCeu9esHNRmB2BOU91AI2RgUMPjt586jW/9+FsDJUjvfP111NW9us/BbYAaFOSIiEhOCnYq01ucc7vNbBbwEzN7JjzTOeeCQIis6bcBtwG0tbWdNL8YOYd+yDKoB1UQqOQquQFo7zvGE0de4fzp02hbUD8oAMol/dLz/Oapp0nuaWbhWxbm7S4+VEmSiIhIhoKdCuSc2x38PmBm3wWWA/vN7Czn3F4zOws4MB77Dg/90DP/9dx55DRW7uodCCRy9aCa01SXs+Smve8YH+jcSdJz1ESMB1rOoa1uat59b/nZLzj1hs8zbflfwO7jHP/VL1l47ZtoWdxy0rJDlSQVK7uHmIiIVB8FOxXGzKYCEefcy8HfFwGfAR4CVgOfC34/OF5pqG1tZfsZjUHJybODSk527+gd1INq947egdKdpVklN08ceYWk50gDeI4njrySN9hp7zvGfd//MdfUNYFFsUgU0i7v25HzlSQNh0qHREQmBwU7lWc28F0zA//83OOce9jMngTuM7M/BnYBHxzPROQrOZnXXD+oB9W85vzBwfnTp1ETMQhKds6fPu2kl/9lPm865XS2nLuQ3/z8Hk5xaZwHVhPN+3bkfG2AxiKPIiJSXRTsVBjnXBfwphzTDwPvKFU68pWczGka3INqToGhGtrqpvJAyzkDbXZmH31p0Mv/Lr74Yh5++GHS6TQWjdL3xvO5/iMf4r1Pb2T5jEYaLnhDwTGvskuSxiqPIiJSXcy5EbVjlQrX1tbm2tvbR7WNsW7Psn79eh599FFc8C6dpqYmurq6Bj6/7vy30HX8OFPuXQueR6ymhstuvDnvUBNjQW12RCTMzDY75zRScJVRyY7kNdqSk2yDXv4XifKayBx2RXaR9vySntfVxtl757/gpdMApJPJguNqjYWxzqOIiFQeBTsyakMNwhkexHP16tXs7HyWuZu2Mmf7Q9TZ6zm0/HWc0/I69rT/As/zBtazSGRgXK1BA4FmvVRwohrULb9ALzURERkdBTsyKkMNwtnXt+WkQTyXp49zauQfMVIsIsbx9B1MbWggevwVYjU1pJJJIpEI77j6o0ydfZxnnrmRPXsfwLnUqwOBljngGW3wNdxu+SIiMnIKdmRUhhqEs7d3I56XAF4dxPPsaC9GCjMPXIop0a3Ae04aQHTq7ONBoHQC/6XSDGzjlCPnDLxpuVAj5vGQK4AbbsAznG75IiIyOgp2ZFSGGoSzvn4FkUgcz0sSidRQX7+CWEsK1/llXDoJsRpiLRcOLD83NIBod/dXgkAp04jeiERqOP1YG4fu3eqPoRWLMHPN4pIGPLkCuOEGO7m65YuIyPhQsCOjMtQgnHV1S1jSetfgKp86sI/8J3Svh8ZV0LA857bDgZJZlLlnfYCzzno/tuVMXKobHLiUl/fFg+MlO4CbeXwarL+lYF6yZXfLV6mOiMj4UdfzKjUWXc9Has+O7QNVUaPtSZWrbcyJXUc5dPvwSnaGakQ90nTNPD6Nad/5W0gnIBqH1Q8VHfCISOVR1/PqpJIdGTPtfcd4eGcXfXev5ay93URjsRG/Jycc5DQ2/umgeVMWnD5odPSnSbPhpzvzvitnqEbUw3Fi11FOdPVxStM5NDYu8Ut00glwaf939/qyBDv9HR3+CPXLl+UcpV5EZDJTsCNjItO7KJH2sHd/mDc8u5k3PPfUiN6TU0wD4CkLTmfKgtOLGt9qqEbUhfIUrmYKlyg5M2LvaeKsxlV+iU6mZKdx1bDyOhb6Ozp44aqrcYkEFo8z/847FPCIiIQo2JExkeld5JlBNMovFy5j2+uWcOGc2mFvazgNgIsZ32qoRtS55Ooa3tzVh0t5flshz2Pb/c9h17UwZ/VDQ7Y/Gk/9m57EJRLgebhk0i/hUbAjIjJAwY6MiUzvIs9zODMww0UiPHf6TN49zG2d1IMrcVreBsDFjG81VCPqXHJ1DV/cVIczw3keHnAwGYz6fvHysrbTqV2+DIvHcckkVlND7fJlZUuLiEglUrAjYyLTu+i+fS9x797DpB35u1T3bCpYEjKoB1fiNOru+5u8DYBzjX7eeaCT9v3ttM1uo2VWC+AHPLmCnH1dfTkHNc3VNXxK3VReXnYqLz5+lEMpeNms4KjvpVLb2sr8O+9Qmx0RkTzUG6tKlbM3VsFhEHo2wbr3Ft97af0t8OjNfgNgi8Lbb4BVH8u7eOeBTq758TUk0gni0ThrL1o7EPBk+9H2/XzjkS7m70/S2Odx6fWtgwKe7Hzs2bGd+2+6Ac+dSTQ+n7d9+HdZfMFJA9SLyASm3ljVSSU7Muba6qbmf29M9/rh9V4aZgPg9v3tJNIJPDySXpL2/e05g532vmNcs3cvyfNOIfr6U7jy8Zf9KqlQsJOdj55tW0mnUjhvNy69l/7ec4HSBztj3Y1eRKTaKdiR0hpu76WG5X7pT5ENgNtmtxGPxkl6SWoiNbTNzv0P2hNHXiFl4MxI43hhds2QVVINixYTjcVIp1JEY7GBQUpLaSy70YuITBYKdiqImTUA3wBm44+RcJtz7stm9mngGuBgsOjfO+d+WJ5UjtIwg5eBdYpsANwyq4W1F609qc1OtvOnTyMeMZKeI2rGlUvmUrvrKCeilvcFhdljd432hYkZw3kJ40i70YfpnTwiMtko2KksKeBjzrktZnYasNnMfhLMu9U5909lTNvYGUbwMhIts1ryBjkZbXVTeXDmHPbueImZM2s56+EXOVrEG5nTp04jMfMs0qeOzVhWmXZAmdKioV7COJJu9GF6J4+ITEYKdiqIc24vsDf4+2Uz2w7MK2+qqtOJXUeZee9OZqQ8v5u85zfULzTW1nhUIb3aDsgjnUoN+RLGkXSjD9M7eURkMoqUOwGSm5k1Aq3AxmDSdWb2lJndYWY5G5eY2bVm1m5m7QcPHsy1iAROhF4QiHMQMTCwWIQpoUbKYbmqkEYr0w7IIpGi2wE1NDSwatWqEQVamXfyEI3qnTwiMmmo63kFMrNpwOPAzc65/zCz2cAh/K/mm4CznHNXF9pGObue57Ovq4+tm58lGe9j8ZLXj3vD2nzv0IGTBxOt+90mvP4UU5rq8lZhjVfj4LEcOLUYarMjkp+6nlcnBTsVxsxqgO8DP3LOfSnH/Ebg+865NxTazlgGO5nBLwsFAkDOl/ll7Ovq4/5/fYzDp/8S8IjGYnzkI+PXk2hfVx8P3tpBOuURjUVOeocODM5X+qXniwoAsrt9K3AQqS4KdqqT2uxUEDMz4P8B28OBjpmdFbTnAXg/8HSp0pRdApKv8W74ZX7nnGL8zRvey3lnv29gTKvdO3r5TaQX8MAYcU+iYu3e0Us65eEcpNPeSe/QgVcHEx1Oo93wm5jV2FdEZGJQm53K8lvAlcDbzawz+LkE+IKZbTWzp4C3AdeXKkHhti2Zxru5ZF7mNz+eZM2Mlzm2/x62dFxJX98WAOY113OKVw9EwDGinkSFbN7Vy7//dCebd/UO7C8ai2ARsIix4eVjA/Oy5Wq0W1DPJlh/C4mf3T+89cpsX1cfmx/uZl+ec1hJOg90cvvW2+k80FnupIhIFVDJTgVxzv0MsByzyvZOnSlNdVgsMlCyk6/xbuZlfueekiBqYLhBI5bPaarjsr+4gK2bzxrzNjubd/Vyxe0bSKQ84rEId69ZydKmei69vpVNG/fwpV/u4oUt3cSfesGflzUq+rAG0gwNd1FnMY7MnsHxA5Xf2LeYar1KMZwhP0REiqFgRwqasuB0Zq5ZPGSbnVlHpnADf8RLsR6ikR+AS/sjltevGFhmTlMdL85YxBNHXmHW6dPIhDqjHf5gQ9dhEikPz0Ey5bGh6zBLF/iNknt2HeSFp9InzQsb1kCaoeEuDJj70d/h6JHmcW2zMxbDQxRTrVcpih3yQ0SkWAp2ZEiZti35ZL8Yr+H6/0P8jL3U168YaLMD/nhUH+jcSTIYSfyBlnOYffSlUfdwWtk0g3gsQjLlUROLsLJpRlHzwmpbW4sLVrKGu4if/0FmjuMLEseqB1imWi+d9ohGIxUxWns+xQ75ISJSLAU7MmrZL8br3ZVgxZI/PWm5J468QtJzpAE8xxNHXqH1hdEPf7B0QT13r1nJhq7DrGyaMajkptC8ERnJcBejMBbDQ4Bfqnbp9a15u+JXkmKH/BARKZaCHRm1YgfIPH/6NGoiBkHJzvnTpzE7MrrhDzKWLqjPG8gUmjci4zzcRUZf3xZOP/3n1NUdpq9vxqgbdc9pqqvoICesmCE/RESKpffsVKlSv1Sw2Bfjtfcd44kjr3D+9Gm01U0FxqZNSrXp69vClo4r8bwEZjVEI39LU9OFOj4i40zv2alOKtmRMTG3eWFRb/9tq5s6EORkhN9dM5mFA8ZEfCOelwA8nEuxYMFvdIxEREZIwY5UrL6+LfT2bjypoXOlKvQG6aFkN/L+nb/7IyKROJ6XPKlXm4iIDI+CHalI4WqcSCTOkta7KjrgGe27YbIbeR/emWLJ2++aUMGeiEilUrAjFam399VqnPDLCSvVSN4NE26/lKuRd13dworOs4jIRKFgRypSff2KCVWNM9x3w+R659BlN95c0tHPw4od7FVEZCJSsCMVqa5uCUtaJ041znDfDZPrnUN/WWQj77BCQUqxPeSKHexVRGSiUrAjFauubknFBzlhw3k3TK53Dg3o2VTUSwsLBSnZDZ4vu/HmvAFPrsFeFeyISDVRsCNSBm11U3mg5ZyT3jkUHmiUaNx/W3OegCdXkNKbduze0cuRvdsHNXju2bY1b7BT7GCvw1JkwCYiUgoKdkRKbPOu3oHhK/5ywezBM0MDjZJO+J/zBAvZQcqxU6I8FIxsHolOJxo/m3TixYJvtYbiB3st2jACtoqgwEyk6inYESmhzbt6ueL2DSRSHvFYhLvXrBw8lEXWQKM0rsq7rewg5entLw2MbO558MZ3XkXt1F8X1eB5qMFeh2UYAVvZTbTATERGRMGOSAlt6DpMIuXhOUimPDZ0HR4c7AxzoNFwkDIv7QaNbL7w/GbmNC0bz+zkNoyArewmUmAmIiOmYGcCMbOLgS8DUeB259znypwkGaaVTTOIxyIkUx41sQgrm2acvNAIBxqtmJHNSzwy/KhMpMBMREZMA4FOEGYWBXYA7wReBJ4E/tA596tcy5d6IFApXrjNzpiOxi4DhjV0h9rsSIgGAq1OKtmZOJYDO51zXQBmdi9wKZAz2JHKtXRBvYKccTTsoTtGWJImIhNHpNwJkKLNA3pCn18Mpg0ws2vNrN3M2g8ePFjSxEl59Hd0cOhrt9Hf0VHupFSMXEN3iMjkppKdKuKcuw24DfxqrDInR8ZZf0cHL1x1NS6RwOJx5t95B7WtreVOVtkNd+gOEal+CnYmjt1AQ+jz2cE0maT6Nz2JSyTA83DJJP2bnlSww/CH7hCR6qdgZ+J4EjjXzF6DH+RcDnyovEmScqpdvgyLx3HJJFZTQ+3yMnQzr1DDGbqjVPZ19ZW/p5zIJKVgZ4JwzqXM7DrgR/hdz+9wzm0rc7KkjGpbW5l/5x1+ic7yZSrVqWD7uvp4MHi7dTQW4dLrWxXwiJSQgp0JxDn3Q+CH5U6HVI7a1tYxD3J6enro7u6msbGRhoaGoVeQIe3e0Tvwdut02mP3jl4FOyIlpGBHRAb09PSwbt060uk00WiU1atXK+AZA/Oa6we93Xpes149IFJKCnZEZEB3dzfpdBrnHOl0mu7ubgU7Y6Bi3m4tMkkp2BGRAY2NjUSj0YGSncbGxnInqWrMaapTkCNSJgp2RGRAQ0MDq1evVpsdEakqCnZEZJCGhgYFOSJSVTRchIiIiFQ1BTsiIiJS1RTsiEjR2vuO8S+79tPed6zcSRERKZra7IhIUdr7jvGBzp0kPUdNxHig5Rza6qaWO1kiIkNSyY6IFOWJI6+Q9BxpIOk5njjySkn229/RwaGv3UZ/R0dJ9ici1UclOyJSlDfGdhMzBy5CTSTC+dOnjfs++zs6eOGqq3GJBBaPM//OOzQGmIgMm0p2RGRIfX1bcM9dySe9f+AD3MfXz0mXpAqrf9OTuEQCPA+XTNK/6clx32c+fX1b6O7+Cn19W8qWBhEZGZXsiMiQens34nkJzuUZznXP0ZicDywZ9/3WLl+GxeO4ZBKrqaF2+bJx32cufX1b2NJxJZ6XIBKJs6T1LurqlrBnx3Z6tm2lYdFi5jYvLEvaRGRoCnZEZEj19SuIROJ4XpJIpIb6+hUl2W9tayvz77yD/k1PUrt8WdmqsDLBHnh4XpLe3o0c238q9990A+lUimgsxmU33qyAR6RCKdgRmWx6NkH3emhcBQ3Li1qlrm4JS1rvord3I/X1K6irG/9SnYza1tayt9PJFew98+hW0qkUzvNIp1L0bNuqYEekQinYEZlMejbBuvdCOgHROKx+aCDg6TzQSfv+dtpmt9Eyq+WkVevqloxrkFOqKqHNu3rZ0HWYlU0zWLqgvqh1cgV7DYtOJRqLDZTsNCxaPG77F5HRUbAjMpl0r/cDHZf2f3evh4bldB7o5JofX0MinSAejbP2orU5A57xsmfH9pJUCW3e1csVt28gkfKIxyLcvWblsAKecLA3t3khl91487ACtNHsX0RGTr2xKoSZfdHMnjGzp8zsu2Y2PZjeaGbHzawz+PlqmZMqE1njKr9Ex6L+78ZVALTvbyeRTuDhkfSStO9vL2myeradXCU0HjZ0HSaR8vAcJFMeG7oOj2p7c5sXsuL9Hyw6MBvr/YtIcVSyUzl+AnzSOZcys88DnwQ+Hsx73jnXUraUSfVoWO5XXWW12Wmb3UY8GifpJamJ1NA2uy3vJsajGqZh0eKTqoTa+47xxJFXOH/6tDHr5r6yaQbxWIRkyqMmFmFl04wx2e5E2b/IZGXOuXKnQbKY2fuBDzjnrjCzRuD7zrk3DGcbbW1trr29tP+dy8Q2VJsdGN9qmHCbnT2z54/b0BTlbjNT7v1LYWa22TmXP9qXCUklO5XpauDboc+vMbMO4CjwKefc+lwrmdm1wLUA8+fPH/dESnVpmdUyZDudXNUwY/WFPbd54UB10AO79g8MTUEwNMVYBTtLF9SXNchYuqCehS910//wo/QX2Z2+p6eH7u5uGhsbaWhoKEEqRaqLgp0SMrNHgDk5Zt3gnHswWOYGIAXcHczbC8x3zh02s6XA98xskXPuaPZGnHO3AbeBX7IzHnmQya1U1TDnT59GTcQgKNkpxdAUpXBi11GOPvILDv/Lx/0XJRYxBEZPTw/r1q0jnU4TjUZZvXq1Ah6RYVKwU0LOuQsLzTezjwC/C7zDBfWLzrkTwIng781m9jzQDKiOSkpu6YJ67l6zctyrYdrqpvJAyzlj3mannE7sOsqh27fym22P404kADcwBEahYKe7u5t0Oo1zjnQ6TXd3t4IdkWFSsFMhzOxi4O+Atzrn+kPTzwRecs6lzawJOBfoKlMyRUZcDTTcqpi2uqlVEeRknOjqw6U8YjObSURj4NJFDYHR2NhINBodKNlpbGwsTYJFqoiCncrxb8AU4CdmBrDBOfdR4LeBz5hZEvCAjzrnXipfMkWGbzJXxWR6lbXNncKCWITojNdS+9a/YcqCI5x+0aoh2+w0NDSwevVqtdkRGQUFOxXCOXdOnunfAb5T4uSIjKnJWhXT3ndsUK+ye/7oXN6w5wRTmt7ElAWnF72dhoaGSXG8RMaLXiooIuMuUxVjZhOiKmZfVx+bH+5mX1ffqLbzxJFXBnqVJT1H+ymO09/WMKxAR0RGTyU7IjLuJlJVzL6uPh68tYN0yiMai3Dp9a3MaarLu/yJXUc50dXHlKa6k4KYau1VJjLRKNgRkZKYKFUxu3f0kk55OAfptMfuHb15g51MDyuX8rBYhJlrFg8KeKqxV5nIRKRgR0QkZF5zPdFYhHTaIxqNMK85f8+zTA8rHLiU55fwZJXuVFuvMpGJSMGOiEjInKY6Lr2+ld07epnXXF+wCmtKUx0WiwyU7EwpsKyIlI+CHRGRkBO7jlK76yhvWHjGkA2Jpyw4nZlrFudtsyMilUHBjohIYKg2OLlMWXB6UUGOBgAVKR8FOyIigWLa4IzEeI4WLyJD03t2RKSq9fVtobv7K/T1bRly2UwbHIwxbYOTa7R4ESkdleyISNXq69vClo4r8bwEkUicJa13UVe3JO/y49UGp1SjxYtIbgp2RKRq9fZuxPMSgIfnJent3Vgw2IHi2+AMR/Zo8dFTd3H71u/QNruNllktY7ovETmZgh0RqVr19SuIROJ4XpJIpIb6+hVlS0tmtPjOA51c8+NrSKQTxKNx1l60VgGPyDhTsCMiVauubglLWu+it3cj9fUrhizVKYX2/e0k0gk8PJJekvb97cMOdjoPdNK+v10lQyJFUrAjIlWtrm5JRQQ5GW2z24hH4yS9JDWRGtpmtw1rfZUMiQyfgh0RkRJqmdXC2ovWjrhkZixKhkQmGwU7IiLjoL3vWN4BQFtmtYw4QBltyZDIZKRgp4KY2aeBa4CDwaS/d879MJj3SeCPgTTwl865H5UlkSIypPa+Y3ygcydJz1ETMR5oOWfMBgMdbclQf0cH/ZuepHb5MmpbW8ckTSKVTsFO5bnVOfdP4Qlmdh5wObAImAs8YmbNzrl0ORIoIoU9ceQVkp4jDeA5njjyypiOfD7SkqH+jg5euOpqXCKBxePMv/MOBTwyKegNyhPDpcC9zrkTzrlfAzuB5WVOk4jkcf70adREjChQEzHOnz4NejbB+lv832XSv+lJXCIBnodLJunf9GTZ0iJSSirZqTzXmdmHgXbgY865XmAesCG0zIvBtEHM7FrgWoD58+eXIKkik1tPTw/d3d00NjbS0NAwML2tbioPtJzzapudo9tg3XshnYBoHFY/BA2l/3+ldvkyLB7HJZNYTQ21y5eVPA0i5aBgp8TM7BFgTo5ZNwBfAW4CXPD7FuDqYrftnLsNuA2gra3NjTqxIpJXT08P69atI51OE41GWb169UkBz0DV1VPr/UDHpf3f3evLE+y0tnL8/3yZ3Y/9nHkX/JaqsGTSULBTYs65C4tZzszWAt8PPu4GGkKzzw6miUiZdHd3k06ncc6RTqfp7u4eFOwM0rjKL9HJlOw0riptYgObd/VyxRPHSETeSPyJY9x9Xm/O0dcTT/4U71c/JXLe24gve9ug9TNDXmjUdplIFOxUEDM7yzm3N/j4fuDp4O+HgHvM7Ev4DZTPBcpX8S8iNDY2Eo1GB0p2Ghsb8y/csNyvuupe7wc6oyjV2bNjOz3bttKwaDFzmxcOa90NXYdJxX5N7PQu0v1NbOg696SgJfHkT4l9/4MYKVzXV0hwH/Flb/MDpds3kEh5xGMR7l6zUgGPTBgKdirLF8ysBb8aqxv4EwDn3DYzuw/4FZAC/lw9sUTKq6GhgdWrV+dss5N7heXDCnJytQfas2M79990A+lUimgsxmU33jysgGfmjL2cMv92sBS4GDNnLAbOGbSM96ufYqQw88Cl8H71U1j2NjZ0HSaR8vAcJFMeG7oOK9iRCUPBTgVxzl1ZYN7NwM0lTI6IDKGhoWHoIGcE8rUH6tm2lXQqhfM80qkUPdu2DivYedmeJRJJ43BELM3L9iwwuEotct7bcF1fAZfCESNynl+NtbJpBvFYhGTKoyYWYWXTjLHMssi4UrAjIlIifX1bihqUNF97oIZFi4nGYgMlOw2LFg9r/22z25gSjZNMJ6gxo81qT1omvuxtJLjvpDY7SxfUc/ealWqzIxOSgh0RkRLo69vClo4r8bwEkUicJa13DQp4wm82ztceaG7zQi678eYRt9lpmdXC2pbraf/vG2g7fpyWF/4a6s45qXotvuxttDcv97vO9x0b6FW2dEG9ghyZkBTsiIiUQG/vRjwvAXh4XpLe3o0DwU6uNxvnaw80t3nhsIOcsJbevbQc6fO7wVs0Zzf48RzuQqQc9AZlEZESqK9fQSQSB6JEIjXU168YmJfrzcYNDQ2sWrWq6DZB+7r62PxwN/u6+govmOkGb9G83eDDw10kg+EuRCYyleyIiJRAXd0SlrTelbPNzmjfbLyvq48Hb+0gnfKIxiJcen0rc5rqci9cRDf4zHAXBCU750+fNqz0iFQaBTsiIiVSV7ckZ8Pk2tZW5t95x4hHI9+9o5d0ysM5SKc9du/ozR/swJDd4DPDXfzsl53M3/Nr5p4Vh7qRV52JlJuCHRGRClDb2jri4RvmNdcTjUVIpz2i0QjzmkffiHju/hewtbfQnUrR84P/4N3Xf5j4GXuH7EkmUokU7IiITHBzmuq49PpWdu/oZV5zfeFSnSINfqdPks2PfYFZLQdz9iQTqXQKdkREqsCcproxCXIy6hfEiUTBw4hEjalzXiZXTzKRiUDBjoiIDNLXt4XdR2+g6ZIIx/adxnkrLuel5NfwvJN7kolMBAp2REQmsH1dfWNafQXwwvOP46UTTJ3jMXXOCerm1dBYn7snWXvfMf/lg9On6V08UrEU7IiITFDD6nI+jG1uefA05v5WFItAJBobCHCyq6708kGZKPRSQRGRCSpXl/Ox2OaxA0288PjHOLTtUqYmvpi3fY5ePigThUp2REQmqPHocp7Z5one15I6ei4L3pO/O7xePigThTnnyp0GGQdtbW2uvb293MkQkXE2Hm12hrPNamuzY2abnXNt5U6HjC0FO1VKwY6IyPAp2KlOqsaqEGb2beB1wcfpwBHnXIuZNQLbgWeDeRuccx8tfQpFREQmJgU7FcI59weZv83sFiA8dPHzzrmWkidKRESkCijYqTBmZsAHgbeXOy0iIiLVQF3PK88qYL9z7rnQtNeYWYeZPW5mq/KtaGbXmlm7mbUfPHhw/FMqIlWvp6eH9evX09PTU+6kiIyYSnZKyMweAebkmHWDc+7B4O8/BL4VmrcXmO+cO2xmS4Hvmdki59zR7I04524DbgO/gfLYpl5EJpuenh7WrVtHOp0mGo2yevVqGhoail5/z47t9GzbSsOixcxtXjiOKRUpTMFOCTnnLiw038xiwO8BS0PrnABOBH9vNrPngWZAXa1EZFx1d3eTTqdxzpFOp+nu7i462NmzYzv333QD6VSKaCzGZTferIBHykbVWJXlQuAZ59yLmQlmdqaZRYO/m4Bzga4ypU9EJpHGxkai0ShmRjQapbGxseh1e7ZtJZ1K4TyPdCpFz7at45dQkSGoZKeyXM7gKiyA3wY+Y2ZJwAM+6px7qeQpE5FJp6GhgdWrV9Pd3U1jY+OwqrAaFi0mGosNlOw0LFp80jL9HR30b3qS2uXLqG3N/6ZmkdHSSwWrlF4qKCLlcGLXUU509TGlqY7DJ3bnbbPT39HBC1ddjUsksHic+XfeUREBj14qWJ1UsiMiImPixK6jHLp9Ky7lYbEIM9csZu77c7fT6d/0JC6RAM/DJZN+CU8FBDtSndRmR0RExsSJrj5cygMHLuVxoqsv77K1y5dh8ThEo1hNDbXLl5UwpTLZqGRHRETGxJSmOiwWGSjZmVJgENHa1lbm33mH2uxISSjYERGRMTFlwenMXLN4oM3OlAWnF1y+trVVQY6UhIIdEREZM1MWnD5kkCNSamqzIyIiIlVNwY6IiIhUNQU7IiIiUtUU7IiIiEhVU7AjIiJjovNAJ7dvvZ3OA53lTorIIOqNJSIio9Z5oJNrfnwNiXSCeDTO2ovW0jKrpdzJEgFUsiMiImOgfX87iXQCD4+kl6R9v8bmk8qhYEdEREatbXYb8WicqEWpidTQNltjaUrlUDWWiIiMWsusFtZetJb2/e20zW5TFZZUFAU7IiIyJlpmtSjIkYqkaiwREakIPT09rF+/np6ennInRaqMgp0SM7PLzGybmXlm1pY175NmttPMnjWzd4WmXxxM22lmnyh9qkVExldPTw+f+48H+afn/N8KeGQsqRqr9J4Gfg/4WniimZ0HXA4sAuYCj5hZczD734F3Ai8CT5rZQ865X5UuySIio9fXt4Xe3o3U16+grm7JoHk/+vULPLhoJelIhM2eR+uvX2BNQ8OgZU7sOlr0iOoiYQp2Ssw5tx3AzLJnXQrc65w7AfzazHYCy4N5O51zXcF69wbLKtgRkQmjr28LWzquxPMSRCJxlrTeNSjg2VN3JunDr+AsQtr8z2Endh3l0O1bcSkPzzyil9Qz7y1vLHU2ZIJSNVblmAeEy21fDKblm34SM7vWzNrNrP3gwYPjllARkeHq7d2I5yUAD89L0tu7cdD8SxrnEY9EiOCIRyNc0jj4MXeiqw+X8sABacfWu3/Anh3bS5cBmdBUsjMOzOwRYE6OWTc45x4cr/06524DbgNoa2tz47UfEZHhqq9fQSQSx/OSRCI11NevGDS/rW4q32k9lyeOvML506fRVjd10PwpTXV45oHn8JzH/v5d9GzbytzmhaXMhkxQCnbGgXPuwhGsthsIV1CfHUyjwHQRkQmhrm4JS1rvyttmB/yAJzvIyZiy4HSil9Sz9e4fsL9/F0e8AzQsWjzeyZYqoWCncjwE3GNmX8JvoHwusAkw4Fwzew1+kHM58KGypVJEZITq6pbkDHKKNe8tb8Rm1dCzbSsNixarVEeKpmCnxMzs/cC/AmcCPzCzTufcu5xz28zsPvyGxyngz51z6WCd64AfAVHgDufctjIlX0SkrOY2L1SQI8NmzqlpRzVqa2tz7e0aiE9EJr59XX3s3tHLvOZ65jTVjeu+zGyzc04De1UZleyIiEjF2tfVx4O3dpBOeUTwuPi9dTS+e1m5kyUTjLqei4hIxdq9o5d0ysM5SKcdz/zrvfR3dJQ7WTLBKNgREZGKNa+5nggeeGkiLs30l56lf9OT5U6WTDCqxhIRkYo1p6mOi99bxzP/ei/TX3qW6b/ZTe1yVWPJ8CjYERGRirF5Vy8bug6zsmkGSxfUA9D47mXMmhOjf9OT1C5fRm1ra5lTKRONgh0REakIm3f1csXtG0ikPOKxCHevWTkQ8NS2tirIkRFTmx0REakIG7oOk0h5eA6SKY8NXYfLnSSpEgp2RESkIqxsmkE8FiFqUBOLsLJpRrmTJFVC1VgiIlIRli6o5+41K09qs1OszgOdtO9vp212Gy2zWsYnkTIhKdgREZGKsXRBPUsjz0H3gxBZBQ3Li1qv80An1/z4GhLpBPFonLUXrVXAIwMU7IiISOXo2QTr3gvpBETjsPqh/AFPzyboXg+Nq2g/8hSJdAIPjxPpBA8+s17BjgxQmx0REakc3ev9QMel/d/d63MvlwmKHr0Z1r2X33anEIvU4JzheVHuXV/D5l29pU27VCwFOyIiUjkaV/klOhb1fzeuyr1cVlDU3LefS878NMmDF9H/whoSrzSoN5cMUDWWiIhUjoblftVVUD2VtworExRlqrsaV/E+71zu/3kUS3nqzSWDmHOu3GmQcdDW1uba29vLnQwRkfETarOTCYpyvYF5OMxss3OubayTKuWlkh0REZmYGpafVPKzdEH9iIIcqW5qsyMiIiJVTcFOiZnZZWa2zcw8M2sLTX+nmW02s63B77eH5j1mZs+aWWfwM6s8qRcREZl4VI1Vek8Dvwd8LWv6IeA9zrk9ZvYG4EfAvND8K5xzaoQjIiIyTAp2Ssw5tx3AzLKnd4Q+bgNONbMpzrkTJUyeiIhI1VE1VmX6fWBLVqBzZ1CFdaNlR0oBM7vWzNrNrP3gwYOlSamIiEiFU7AzDszsETN7OsfPpUWsuwj4PPAnoclXOOcWA6uCnytzreucu8051+acazvzzDPHIisiIiITnqqxxoFz7sKRrGdmZwPfBT7snHs+tL3dwe+XzeweYDnwjULb2rx58yEz2zWM3c/Ebzc0GU3WvE/WfMPkzftkzTcUn/cF450QKT0FOxXCzKYDPwA+4Zz7eWh6DJjunDtkZjXA7wKPDLU959ywinbMrH2yvkhrsuZ9suYbJm/eJ2u+YXLnXVSNVXJm9n4zexF4M/ADM/tRMOs64BzgH7K6mE8BfmRmTwGdwG5gbRmSLiIiMiGpZKfEnHPfxa+qyp7+WeCzeVZbOq6JEhERqWIq2ZGM28qdgDKarHmfrPmGyZv3yZpvmNx5n/Q0EKiIiIhUNZXsiIiISFVTsCMiIiJVTcHOJGJmZ5jZT8zsueB3fZ7lHjazI2b2/azprzGzjWa208y+bWbx0qR89IaR99XBMs+Z2erQ9Ak1GKuZXRykd6eZfSLH/CnBOdwZnNPG0LxPBtOfNbN3lTThozTSfJtZo5kdD53fr5Y88aNURN5/28y2mFnKzD6QNS/ndT8RjDLf6dA5f6h0qZaSc87pZ5L8AF/Af48PwCeAz+dZ7h3Ae4DvZ02/D7g8+PurwJ+WO09jmXfgDKAr+F0f/F0fzHsMaCt3PorMaxR4HmgC4sAvgfOylvkz4KvB35cD3w7+Pi9YfgrwmmA70XLnqQT5bgSeLncexjnvjcAb8V9I+oHQ9LzXfaX/jCbfwbxXyp0H/ZTmRyU7k8ulwLrg73XA+3It5Jz7b+Dl8LRgPK63Aw8MtX6FKibv7wJ+4px7yTnXC/wEuLg0yRtTy4Gdzrku51wCuBc//2Hh4/EA8I7gHF8K3OucO+Gc+zWwM9jeRDCafE90Q+bdOdftnHsK8LLWncjX/WjyLZOIgp3JZbZzbm/w9z5g9jDWnQEccc6lgs8vAvPGMnHjrJi8zwN6Qp+z8zjkYKwVYqh8DFomOKd9+Oe4mHUr1WjyDfAaM+sws8fNbNV4J3aMjea8Vfs5L+SUYPDkDWb2vjFNmVQUvVSwypjZI8CcHLNuCH9wzjkzq6r3Doxz3q9wzu02s9OA7+APxlpwfDKZUPYC851zh81sKfA9M1vknDta7oTJuFoQ3NdNwKNmttWFxiWU6qFgp8q4AoOQmtl+MzvLObfXzM4CDgxj04eB6WYWC/4jPht/6IqKMQZ53w1cEPp8Nn5bHdwIBmMto91AQ+hzrnOVWeZF88dfq8M/x8WsW6lGnG/nnANOADjnNpvZ80Az0D7uqR4bozlvea/7CWBU12vovu4ys8eAVvw2QFJlVI01uTwEZHparAYeLHbF4Mvgp0CmN8Ow1q8AxeT9R8BFZlYf9Na6CH9cspiZzQSwVwdjfboEaR6pJ4Fzg95zcfyGuNk9TcLH4wPAo8E5fgi4POi19BrgXGBTidI9WiPOt5mdaWZRgOC//HPxG+pOFMXkPZ+c1/04pXOsjTjfQX6nBH/PBH4L+NW4pVTKq9wtpPVTuh/8tgn/DTyHP3L6GcH0NuD20HLrgYPAcfw68HcF05vwv/h2AvcDU8qdp3HI+9VB/nYCVwXTpgKbgaeAbcCXqfAeSsAlwA78/1JvCKZ9Bnhv8PcpwTncGZzTptC6NwTrPQu8u9x5KUW+gd8Pzm0nsAV4T7nzMg55Xxbcz8fwS/G2hdY96bqfKD8jzTdwPrAVvwfXVuCPy50X/Yzfj4aLEBERkaqmaiwRERGpagp2REREpKop2BEREZGqpmBHREREqpqCHREREalqCnZERESkqinYERERkar2/wNDLd2Eydz8NAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(pca.components_,eg.components.T,'.')\n",
+    "plt.title(\"Correlation between NumPy-calculated components and EigenGame-calculated components\")\n",
+    "np.corrcoef(pca.components_,eg.components.T)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
I have added a demonstration of the EigenGame class in action in the /tests/ directory. I graphically compared the results of EigenGame with SKlearn's PCA on the developmental-fmri dataset fetched from Nilearn